### PR TITLE
✨feat(navigation): add `fadeInOutPopTransitionSpec` and refactor pack…

### DIFF
--- a/cmp-navigation/src/androidMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.android.kt
+++ b/cmp-navigation/src/androidMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.android.kt
@@ -1,0 +1,16 @@
+package zone.ien.utils.navigation.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.navigation3.scene.Scene
+import androidx.navigationevent.NavigationEvent
+
+actual fun <T : Any> fadeInOutPopTransitionSpec(): AnimatedContentTransitionScope<Scene<T>>.(@NavigationEvent.SwipeEdge Int) -> ContentTransform = {edge ->
+    ContentTransform(
+        fadeIn(tween(500)),
+        fadeOut(tween(500))
+    )
+}

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
@@ -1,4 +1,4 @@
-package zone.ien.utils.navigation.data
+package zone.ien.utils.navigation
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
@@ -20,6 +20,7 @@ import androidx.navigation3.ui.defaultPopTransitionSpec
 import androidx.navigation3.ui.defaultPredictivePopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
 import androidx.navigationevent.NavigationEvent
+import zone.ien.utils.navigation.transition.fadeInOutPopTransitionSpec
 
 @Composable
 fun <T : NavKey> BaseNavDisplay(
@@ -34,15 +35,9 @@ fun <T : NavKey> BaseNavDisplay(
         ),
     sceneStrategy: SceneStrategy<T> = SinglePaneSceneStrategy(),
     sizeTransform: SizeTransform? = null,
-    transitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform =
-        defaultTransitionSpec(),
-    popTransitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform =
-        defaultPopTransitionSpec(),
-    predictivePopTransitionSpec:
-    AnimatedContentTransitionScope<Scene<T>>.(
-        @NavigationEvent.SwipeEdge Int
-    ) -> ContentTransform =
-        defaultPredictivePopTransitionSpec(),
+    transitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = defaultTransitionSpec(),
+    popTransitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = defaultPopTransitionSpec(),
+    predictivePopTransitionSpec: AnimatedContentTransitionScope<Scene<T>>.(@NavigationEvent.SwipeEdge Int) -> ContentTransform = fadeInOutPopTransitionSpec(),
     entryProvider: (key: T) -> NavEntry<T>,
 ) {
     NavDisplay(

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/ScreenInfo.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/ScreenInfo.kt
@@ -1,4 +1,4 @@
-package zone.ien.utils.navigation.data
+package zone.ien.utils.navigation
 
 import androidx.navigationevent.NavigationEventInfo
 

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
@@ -1,4 +1,4 @@
-package zone.ien.utils.navigation.data
+package zone.ien.utils.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/tracker/ScreenTracker.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/tracker/ScreenTracker.kt
@@ -1,4 +1,4 @@
-package zone.ien.utils.navigation.data.tracker
+package zone.ien.utils.navigation.tracker
 
 import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.kt
@@ -1,0 +1,8 @@
+package zone.ien.utils.navigation.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.navigation3.scene.Scene
+import androidx.navigationevent.NavigationEvent.SwipeEdge
+
+expect fun <T: Any> fadeInOutPopTransitionSpec(): AnimatedContentTransitionScope<Scene<T>>.(@SwipeEdge Int) -> ContentTransform

--- a/cmp-navigation/src/iosMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.ios.kt
+++ b/cmp-navigation/src/iosMain/kotlin/zone/ien/utils/navigation/transition/FadeInOutPopTransition.ios.kt
@@ -1,0 +1,9 @@
+package zone.ien.utils.navigation.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.ui.defaultPredictivePopTransitionSpec
+import androidx.navigationevent.NavigationEvent
+
+actual fun <T : Any> fadeInOutPopTransitionSpec(): AnimatedContentTransitionScope<Scene<T>>.(@NavigationEvent.SwipeEdge Int) -> ContentTransform = defaultPredictivePopTransitionSpec()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.10"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "0.1.4-alpha05"
+lib-version-name = "0.1.4-alpha06"
 
 # pluginπ
 compose-plugin = "1.10.1"


### PR DESCRIPTION
…age structure

- Added `fadeInOutPopTransitionSpec` with platform-specific implementations for Android and iOS.
- Updated `BaseNavDisplay` to use `fadeInOutPopTransitionSpec` as the default `predictivePopTransitionSpec`.
- Refactored package structure by moving files from `zone.ien.utils.navigation.data` and `zone.ien.utils.navigation.data.tracker` to `zone.ien.utils.navigation` and `zone.ien.utils.navigation.tracker`.
- ⬆️chore(lib): bumped version to 0.1.4-alpha06.