### PR TITLE
⬆️ chore(lib): 라이브러리 버전을 0.1.4-alpha11로 업데이트 및 Dropdown 수정

### DIFF
--- a/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/view/Dropdown.kt
+++ b/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/view/Dropdown.kt
@@ -66,7 +66,7 @@ fun AdaptiveDropdownBox(
                     animationSpec = spring(1.2f)
                 )
                 Box(
-                    modifier = modifier.graphicsLayer {
+                    modifier = Modifier.graphicsLayer {
                         this.scaleX = alpha
                         this.scaleY = alpha
                         this.alpha = alpha

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.10"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "0.1.4-alpha10"
+lib-version-name = "0.1.4-alpha11"
 
 # pluginπ
 compose-plugin = "1.10.2"


### PR DESCRIPTION
- 라이브러리 버전을 0.1.4-alpha10에서 0.1.4-alpha11로 업데이트함.
- Dropdown.kt에서 전달받은 modifier 대신 Modifier 상수를 사용하도록 수정. Closes #64