### PR TITLE
✨ feat(navigation): rememberNavBackStack 유틸리티 함수 추가 및 적용

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/rememberNavBackStack.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/rememberNavBackStack.kt
@@ -1,0 +1,26 @@
+package zone.ien.utils.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.serialization.NavBackStackSerializer
+import androidx.savedstate.serialization.SavedStateConfiguration
+import kotlinx.serialization.PolymorphicSerializer
+
+@Composable
+inline fun <reified T: NavKey> rememberNavBackStack(
+    vararg elements: T,
+): NavBackStack<T> {
+    val configuration = getConfig<T>()
+    require(configuration.serializersModule != SavedStateConfiguration.DEFAULT.serializersModule) {
+        "You must pass a `SavedStateConfiguration.serializersModule` configured to handle " +
+                "`NavKey` open polymorphism. Define it with: `polymorphic(NavKey::class) { ... }`"
+    }
+    return rememberSerializable(
+        configuration = configuration,
+        serializer = NavBackStackSerializer(PolymorphicSerializer(T::class)),
+    ) {
+        NavBackStack(*elements)
+    }
+}

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/App.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/App.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation3.runtime.rememberNavBackStack
 import zone.ien.hig.ExperimentalCupertinoApi
 import zone.ien.hig.adaptive.ExperimentalAdaptiveApi
 import zone.ien.hig.adaptive.Theme
@@ -16,8 +15,6 @@ import zone.ien.utils.adaptive.theme.GeneratedAdaptiveTheme
 import zone.ien.utils.adaptive.wrapper.RootWrapper
 import zone.ien.utils.example.ui.navigation.RootNavigationGraph
 import zone.ien.utils.example.ui.navigation.RootRoute
-import zone.ien.utils.example.ui.navigation.rootConfig
-import zone.ien.utils.example.ui.screens.textfield.TextFieldScreen
 import zone.ien.utils.utils.Dlog
 
 const val TAG = "CmpLibTAG"
@@ -32,7 +29,7 @@ expect val isIos: Boolean
 fun App() {
     Dlog.init(isDebug = true)
 
-    val backStack = rememberNavBackStack(rootConfig, RootRoute.Home)
+    val backStack = zone.ien.utils.navigation.rememberNavBackStack<RootRoute>(RootRoute.Home)
     var isMaterialTheme by remember { mutableStateOf(!isIos) }
 
     GeneratedAdaptiveTheme(

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
@@ -27,12 +27,10 @@ sealed interface RootRoute: NavKey {
     @Serializable data object LazySection: RootRoute
 }
 
-val rootConfig = getConfig<RootRoute>()
-
 @Composable
 fun RootNavigationGraph(
     modifier: Modifier = Modifier,
-    backStack: NavBackStack<NavKey>
+    backStack: NavBackStack<RootRoute>
 ) {
     BaseNavDisplay(
         backStack = backStack,

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
@@ -69,7 +69,7 @@ import zone.ien.utils.utils.ifEmptyOrNull
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    backStack: NavBackStack<NavKey>
+    backStack: NavBackStack<RootRoute>
 ) {
     var isMaterialTheme by remember { mutableStateOf(true) }
     var isDropdownMenu by remember { mutableStateOf(true) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.20"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.1.13-alpha21"
+lib-version-name = "2.1.13-alpha22"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- `cmp-navigation` 모듈에 제네릭 타입 `T: NavKey`를 지원하는 `rememberNavBackStack` 인라인 함수를 새롭게 추가했습니다.
- 해당 함수는 `PolymorphicSerializer`를 사용하여 `NavBackStack`의 직렬화를 자동으로 처리하며, 올바른 `serializersModule` 설정 여부를 검증합니다.
- 예제 앱에서 기존의 `androidx.navigation3` 라이브러리 함수 대신 새롭게 정의된 유틸리티 함수를 사용하도록 수정했습니다.
- 라이브러리 버전을 `2.1.13-alpha21`에서 `2.1.13-alpha22`로 업데이트했습니다.