### PR TITLE
✨ feat(utils): Map 확장 함수 추가 및 버전 업데이트

### DIFF
--- a/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/Map.kt
+++ b/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/Map.kt
@@ -1,0 +1,3 @@
+package zone.ien.utils.utils
+
+fun <K, V> Map<K, V>.getWithDefault(key: K, defaultValue: V = this.values.first()): V = this[key] ?: defaultValue

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.20"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.1.14"
+lib-version-name = "2.1.15"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- Map에서 키가 없을 경우 기본값을 반환하는 `getWithDefault` 확장 함수를 새롭게 추가했습니다.
- 기본값은 명시적으로 지정하거나 Map의 첫 번째 값을 사용하도록 구현했습니다.
- 라이브러리 버전을 2.1.14에서 2.1.15로 업데이트했습니다.