### PR TITLE
✨ chore(ui): 버전 업데이트 및 Empty 컴포넌트 개선

### DIFF
--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/view/Empty.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/view/Empty.kt
@@ -79,20 +79,10 @@ fun Empty(
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically,
             content = buttons,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
         )
-//        Text(
-//            text = stringResource(Res.string.no_room_available),
-//            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-//            textAlign = TextAlign.Center,
-//            modifier = Modifier.padding(top = 8.dp)
-//        )
-//        Text(
-//            text = stringResource(Res.string.no_room_available_desc),
-//            style = MaterialTheme.typography.labelMedium,
-//            textAlign = TextAlign.Center,
-//            color = MaterialTheme.colorScheme.outline
-//        )
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.20"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.1.15"
+lib-version-name = "2.1.16"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- lib-version-name을 2.1.15에서 2.1.16으로 업데이트합니다.
- `Empty` 컴포저블의 버튼 레이아웃에 16.dp 패딩을 추가하여 UI를 개선했습니다.
- 불필요한 주석 코드를 제거하여 코드를 정리했습니다.