### PR TITLE
✨ feat(ui): Empty 컴포넌트의 buttons 파라미터 개선 및 버전 업데이트

### DIFF
--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/view/Empty.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/view/Empty.kt
@@ -35,7 +35,7 @@ fun Empty(
     icon: (@Composable (Modifier) -> Unit)?,
     title: @Composable () -> Unit,
     content: (@Composable () -> Unit)? = null,
-    buttons: @Composable RowScope.() -> Unit = {}
+    buttons: @Composable (RowScope.() -> Unit)? = null
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -75,14 +75,16 @@ fun Empty(
         ) {
             content?.invoke()
         }
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-            content = buttons,
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth()
-        )
+        buttons?.let {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically,
+                content = it,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            )
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.20"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.1.16"
+lib-version-name = "2.1.17"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- `lib-version-name`을 2.1.16에서 2.1.17로 업데이트했습니다.
- `Empty` 컴포저블의 `buttons` 파라미터 타입을 nullable로 변경하고 기본값을 null로 수정했습니다.
- `buttons`가 null일 경우 하단 Row 레이아웃이 렌더링되지 않도록 수정하여 불필요한 여백 발생을 방지했습니다.