### PR TITLE
✨ feat(adaptive): DropdownMenu 컴포넌트 구조 개선 및 파괴적 액션 지원

### DIFF
--- a/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/view/Dropdown.kt
+++ b/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/view/Dropdown.kt
@@ -4,50 +4,52 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.kyant.backdrop.Backdrop
-import zone.ien.hig.utils.rememberDefaultBackdrop
 import zone.ien.hig.CupertinoDropdownMenu
 import zone.ien.hig.CupertinoDropdownMenuDefaults
 import zone.ien.hig.CupertinoDropdownMenuNative
 import zone.ien.hig.CupertinoMenuItemData
+import zone.ien.hig.CupertinoMenuScope
 import zone.ien.hig.CupertinoMenuSectionData
 import zone.ien.hig.ExperimentalCupertinoApi
 import zone.ien.hig.MenuAction
 import zone.ien.hig.MenuDivider
 import zone.ien.hig.MenuSection
+import zone.ien.hig.ProvideTextStyle
 import zone.ien.hig.adaptive.Adaptation
 import zone.ien.hig.adaptive.AdaptationScope
 import zone.ien.hig.adaptive.AdaptiveWidget
 import zone.ien.hig.adaptive.ExperimentalAdaptiveApi
+import zone.ien.hig.utils.rememberDefaultBackdrop
 import zone.ien.utils.icon.ComplexIcon
 import zone.ien.utils.icon.IconData
-import kotlin.math.exp
 
 @OptIn(ExperimentalAdaptiveApi::class)
 @Composable
@@ -102,7 +104,8 @@ fun AdaptiveDropdownMenu(
     scrollState: ScrollState = rememberScrollState(),
     properties: PopupProperties = PopupProperties(clippingEnabled = false),
     adaptation: AdaptationScope<HigDropdownMenuAdaptation, M3DropdownMenuAdaptation>.() -> Unit = {},
-    items: List<DropdownMenuSection>,
+    items: List<DropdownMenuSection.Action>,
+    sections: List<DropdownMenuSection>
 ) {
     AdaptiveWidget(
         adaptation = remember { DropdownMenuAdaptation() },
@@ -121,19 +124,13 @@ fun AdaptiveDropdownMenu(
                 shadowElevation = it.shadowElevation,
                 border = it.border,
                 content = {
-                    items.forEachIndexed { index, section ->
-                        if (index != 0) {
+                    items.filter { it.visible }.forEach { it.M3Menu() }
+                    sections.forEachIndexed { index, section ->
+                        if (index != 0 || items.isNotEmpty()) {
                             HorizontalDivider()
                         }
-                        section.items.filter { it.visible }.forEach { action ->
-                            DropdownMenuItem(
-                                text = action.text,
-                                onClick = action.onClick,
-                                modifier = action.modifier,
-                                leadingIcon = action.icon,
-                                enabled = action.enabled
-                            )
-                        }
+                        section.title?.let { DropdownMenuSectionTitle(it) }
+                        section.items.filter { it.visible }.forEach { it.M3Menu() }
                     }
                 }
             )
@@ -151,22 +148,15 @@ fun AdaptiveDropdownMenu(
                 properties = properties,
                 backdrop = it.backdrop,
                 content = {
-                    items.forEachIndexed { index, section ->
-                        if (index != 0) {
+                    items.filter { it.visible }.forEach { ActionToUIMenu(it) }
+                    sections.forEachIndexed { index, section ->
+                        if (index != 0 || items.isNotEmpty()) {
                             MenuDivider()
                         }
                         MenuSection(
                             title = section.title,
                         ) {
-                            section.items.filter { it.visible }.forEach { action ->
-                                MenuAction(
-                                    onClick = action.onClick,
-                                    modifier = action.modifier,
-                                    leadingIcon = action.icon,
-                                    title = action.text,
-                                    enabled = action.enabled
-                                )
-                            }
+                            section.items.filter { it.visible }.forEach { ActionToUIMenu(it) }
                         }
                     }
                 }
@@ -185,7 +175,8 @@ fun AdaptiveDropdownMenuNative(
     scrollState: ScrollState = rememberScrollState(),
     properties: PopupProperties = PopupProperties(clippingEnabled = false),
     adaptation: AdaptationScope<HigDropdownMenuAdaptation, M3DropdownMenuAdaptation>.() -> Unit = {},
-    items: List<DropdownMenuSectionNative>,
+    items: List<DropdownMenuSectionNative.Action> = listOf(),
+    sections: List<DropdownMenuSectionNative> = listOf()
 ) {
     AdaptiveWidget(
         adaptation = remember { DropdownMenuAdaptation() },
@@ -204,19 +195,13 @@ fun AdaptiveDropdownMenuNative(
                 shadowElevation = it.shadowElevation,
                 border = it.border,
                 content = {
-                    items.forEachIndexed { index, section ->
-                        if (index != 0) {
+                    items.filter { it.visible }.forEach { it.M3Menu() }
+                    sections.forEachIndexed { index, section ->
+                        if (index != 0 || items.isNotEmpty()) {
                             HorizontalDivider()
                         }
-                        section.items.filter { it.visible }.forEach { action ->
-                            DropdownMenuItem(
-                                text = { Text(text = action.text) },
-                                onClick = action.onClick,
-                                modifier = action.modifier,
-                                leadingIcon = action.icon?.let { { ComplexIcon(icon = it) } },
-                                enabled = action.enabled
-                            )
-                        }
+                        section.title?.let { DropdownMenuSectionTitle { Text(text = it) } }
+                        section.items.filter { it.visible }.forEach { it.M3Menu() }
                     }
                 }
             )
@@ -233,34 +218,44 @@ fun AdaptiveDropdownMenuNative(
                 scrollState = scrollState,
                 properties = properties,
                 backdrop = it.backdrop,
-                sections = items.map { section ->
-                    CupertinoMenuSectionData(
-                        title = "",
-                        items = section.items.filter { it.visible }.map { action ->
-                            CupertinoMenuItemData(
-                                title = action.text,
-                                onClick = action.onClick,
-                            )
-                        }
-                    )
-                }
+                items = items.filter { it.visible }.map { it.toUIMenu() },
+                sections = sections.map { it.toUISection() }
             )
         }
     )
+}
+
+@Composable
+private fun DropdownMenuSectionTitle(
+    title: @Composable () -> Unit
+) {
+    ProvideTextStyle(
+        value = MaterialTheme.typography.labelSmall.copy(
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .padding(horizontal = 12.dp)
+        ) {
+            title()
+        }
+    }
 }
 
 data class DropdownMenuSection(
     val title: (@Composable () -> Unit)? = null,
     val items: List<Action>
 ) {
-
     data class Action(
         val text: @Composable () -> Unit,
         val onClick: () -> Unit,
         val modifier: Modifier = Modifier,
         val icon: @Composable () -> Unit = {},
         val visible: Boolean = true,
-        val enabled: Boolean = true
+        val enabled: Boolean = true,
+        val isDestructive: Boolean = false
     )
 }
 
@@ -274,9 +269,59 @@ data class DropdownMenuSectionNative(
         val modifier: Modifier = Modifier,
         val icon: IconData? = null,
         val visible: Boolean = true,
-        val enabled: Boolean = true
+        val enabled: Boolean = true,
+        val isDestructive: Boolean = false
     )
 }
+
+@Composable
+private fun DropdownMenuSection.Action.M3Menu() = DropdownMenuItem(
+    text = text,
+    onClick = onClick,
+    modifier = modifier,
+    leadingIcon = icon,
+    enabled = enabled
+)
+
+@Composable
+private fun CupertinoMenuScope.ActionToUIMenu(action: DropdownMenuSection.Action) {
+    MenuAction(
+        onClick = action.onClick,
+        modifier = action.modifier,
+        leadingIcon = action.icon,
+        title = action.text,
+        enabled = action.enabled
+    )
+}
+
+@Composable
+private fun DropdownMenuSectionNative.Action.M3Menu() = DropdownMenuItem(
+    text = { Text(text = text) },
+    onClick = onClick,
+    modifier = modifier,
+    leadingIcon = icon?.let { { ComplexIcon(icon = it) } },
+    enabled = enabled,
+    colors = if (isDestructive) MenuDefaults.itemColors() else MenuDefaults.itemColors()
+)
+
+@Composable
+private fun DropdownMenuSectionNative.toUISection() = CupertinoMenuSectionData(
+    title = title.orEmpty(),
+    items = items.filter { it.visible }.map { it.toUIMenu() }
+)
+
+@Composable
+private fun DropdownMenuSectionNative.Action.toUIMenu() = CupertinoMenuItemData(
+    title = text,
+    onClick = onClick,
+    enabled = enabled,
+    icon = when (icon) {
+        is IconData.Vector -> rememberVectorPainter(icon.imageVector)
+        is IconData.Paint -> icon.painter
+        null -> null
+    },
+    isDestructive = isDestructive
+)
 
 class M3DropdownMenuAdaptation internal constructor(
     shape: Shape,

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMapIndexed
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.kyant.backdrop.backdrops.layerBackdrop
@@ -71,7 +73,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     backStack: NavBackStack<RootRoute>
 ) {
-    var isMaterialTheme by remember { mutableStateOf(true) }
+    var isMaterialTheme by rememberSaveable { mutableStateOf(true) }
     var isDropdownMenu by remember { mutableStateOf(true) }
     var showVisible by remember { mutableStateOf(true) }
     var showSingle by remember { mutableStateOf(false) }
@@ -188,14 +190,27 @@ fun HomeScreen(
                         expanded = childExpanded,
                         onDismissRequest = { childExpanded = false },
                         adaptation = { cupertino { this.backdrop = backdrop } },
-                        items = listOf(
+                        items = children.fastMapIndexed { index, child ->
+                            DropdownMenuSectionNative.Action(
+                                text = child,
+                                onClick = {
+                                    childExpanded = false
+                                },
+                                icon = IconData.Vector(Android),
+                                isDestructive = index == 1
+                            )
+                        },
+                        sections = listOf(
                             DropdownMenuSectionNative(
-                                items = children.fastMap { child ->
+                                title = "section",
+                                items = children.fastMapIndexed { index, child ->
                                     DropdownMenuSectionNative.Action(
                                         text = child,
                                         onClick = {
                                             childExpanded = false
-                                        }
+                                        },
+                                        icon = IconData.Vector(Android),
+                                        isDestructive = index == 1
                                     )
                                 }
                             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ activity-compose = "1.13.0"
 lifecycle = "2.10.0"
 backdrop = "2.0.0-alpha04"
 haze = "1.7.2"
-hig = "1.0.2-alpha13"
+hig = "1.0.2-alpha14"
 capsule = "1.2.0"
 placeholder = "1.0.2"
 


### PR DESCRIPTION
- `AdaptiveDropdownMenu`에서 `items`와 `sections`를 분리하여 더 유연한 레이아웃 구성을 지원합니다.
- `Action` 데이터 클래스에 `isDestructive` 속성을 추가하여 파괴적 동작(삭제 등)에 대한 UI 스타일을 지원합니다.
- Material 3 환경에서 섹션 타이틀을 표시하기 위한 `DropdownMenuSectionTitle` 컴포저블을 추가했습니다.
- 내부적으로 중복되던 메뉴 아이템 생성 로직을 `M3Menu`, `toUIMenu` 등의 확장 함수로 리팩토링했습니다.
- `libs.versions.toml`에서 `hig` 라이브러리 버전을 `1.0.2-alpha14`로 업데이트했습니다.
- 예제 앱의 `HomeScreen`에서 `isMaterialTheme` 상태 저장 방식을 `rememberSaveable`로 변경했습니다.

Closes #110 