### PR TITLE
✨ feat(utils): String을 ClipEntry로 변환하는 확장 함수 추가

### DIFF
--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
@@ -2,10 +2,8 @@ package zone.ien.utils.utils
 
 import android.content.ClipData
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.toClipEntry
-
-@ExperimentalComposeUiApi
 actual fun String.toClipEntry(): ClipEntry {
+    return ClipData.newPlainText("text_data", this).toClipEntry()
+}
     return ClipData.newPlainText("clip_entry", this).toClipEntry()
 }

--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
@@ -1,9 +1,11 @@
 package zone.ien.utils.utils
 
 import android.content.ClipData
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.toClipEntry
 
+@ExperimentalComposeUiApi
 actual fun String.toClipEntry(): ClipEntry {
     return ClipData.newPlainText("clip_entry", this).toClipEntry()
 }

--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
@@ -2,8 +2,10 @@ package zone.ien.utils.utils
 
 import android.content.ClipData
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.toClipEntry
+
+@ExperimentalComposeUiApi
 actual fun String.toClipEntry(): ClipEntry {
     return ClipData.newPlainText("text_data", this).toClipEntry()
-}
-    return ClipData.newPlainText("clip_entry", this).toClipEntry()
 }

--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/toClipEntry.android.kt
@@ -1,0 +1,9 @@
+package zone.ien.utils.utils
+
+import android.content.ClipData
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.toClipEntry
+
+actual fun String.toClipEntry(): ClipEntry {
+    return ClipData.newPlainText("clip_entry", this).toClipEntry()
+}

--- a/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/toClipEntry.kt
+++ b/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/toClipEntry.kt
@@ -1,0 +1,5 @@
+package zone.ien.utils.utils
+
+import androidx.compose.ui.platform.ClipEntry
+
+expect fun String.toClipEntry(): ClipEntry

--- a/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/toClipEntry.kt
+++ b/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/toClipEntry.kt
@@ -1,5 +1,7 @@
 package zone.ien.utils.utils
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 
+@ExperimentalComposeUiApi
 expect fun String.toClipEntry(): ClipEntry

--- a/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/toClipEntry.ios.kt
+++ b/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/toClipEntry.ios.kt
@@ -1,0 +1,9 @@
+package zone.ien.utils.utils
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun String.toClipEntry(): ClipEntry {
+    return ClipEntry.withPlainText(this)
+}

--- a/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/toClipEntry.ios.kt
+++ b/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/toClipEntry.ios.kt
@@ -3,7 +3,7 @@ package zone.ien.utils.utils
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 
-@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalComposeUiApi
 actual fun String.toClipEntry(): ClipEntry {
     return ClipEntry.withPlainText(this)
 }


### PR DESCRIPTION
- commonMain에 `String.toClipEntry()` expect 함수를 정의합니다.
- androidMain에서 `ClipData`를 사용하여 `ClipEntry`로 변환하는 로직을 구현합니다.
- iosMain에서 `ClipEntry.withPlainText`를 사용하여 변환하는 로직을 구현합니다.

Closes #119