### PR TITLE
✨ feat: navigation3 대응 및 무한 스크롤 구조 개선

### DIFF
--- a/cmp-common/src/commonMain/kotlin/zone/ien/utils/model/InfScrollStateList.kt
+++ b/cmp-common/src/commonMain/kotlin/zone/ien/utils/model/InfScrollStateList.kt
@@ -2,7 +2,7 @@ package zone.ien.utils.model
 
 
 interface InfScrollStateList<T> {
-    val itemList: Map<String, T>
+    val itemList: List<T>
     val lastItemId: Long?
     val isInitialized: Boolean
     val isLoading: Boolean

--- a/cmp-common/src/commonMain/kotlin/zone/ien/utils/model/InfScrollStateList.kt
+++ b/cmp-common/src/commonMain/kotlin/zone/ien/utils/model/InfScrollStateList.kt
@@ -1,0 +1,10 @@
+package zone.ien.utils.model
+
+
+interface InfScrollStateList<T> {
+    val itemList: Map<String, T>
+    val lastItemId: Long?
+    val isInitialized: Boolean
+    val isLoading: Boolean
+    val hasMore: Boolean
+}

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
@@ -2,6 +2,7 @@ package zone.ien.utils.navigation
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.SizeTransform
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,6 +14,7 @@ import androidx.navigation3.runtime.NavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneDecoratorStrategy
 import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SinglePaneSceneStrategy
 import androidx.navigation3.ui.NavDisplay
@@ -21,6 +23,7 @@ import androidx.navigation3.ui.defaultPredictivePopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
 import androidx.navigationevent.NavigationEvent
 import zone.ien.utils.navigation.transition.fadeInOutPopTransitionSpec
+import kotlin.collections.listOf
 
 @Composable
 fun <T : NavKey> BaseNavDisplay(
@@ -33,7 +36,9 @@ fun <T : NavKey> BaseNavDisplay(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator() // 뷰모델 꺼짐 보장
         ),
-    sceneStrategy: SceneStrategy<T> = SinglePaneSceneStrategy(),
+    sceneStrategies: List<SceneStrategy<T>> = listOf(SinglePaneSceneStrategy()),
+    sceneDecoratorStrategies: List<SceneDecoratorStrategy<T>> = emptyList(),
+    sharedTransitionScope: SharedTransitionScope? = null,
     sizeTransform: SizeTransform? = null,
     transitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = defaultTransitionSpec(),
     popTransitionSpec: AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = defaultPopTransitionSpec(),
@@ -46,7 +51,9 @@ fun <T : NavKey> BaseNavDisplay(
         contentAlignment = contentAlignment,
         onBack = onBack,
         entryDecorators = entryDecorators,
-        sceneStrategy = sceneStrategy,
+        sceneStrategies = sceneStrategies,
+        sceneDecoratorStrategies = sceneDecoratorStrategies,
+        sharedTransitionScope = sharedTransitionScope,
         sizeTransform = sizeTransform,
         transitionSpec = transitionSpec,
         popTransitionSpec = popTransitionSpec,

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/BaseNavDisplay.kt
@@ -19,11 +19,9 @@ import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SinglePaneSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.defaultPopTransitionSpec
-import androidx.navigation3.ui.defaultPredictivePopTransitionSpec
 import androidx.navigation3.ui.defaultTransitionSpec
 import androidx.navigationevent.NavigationEvent
 import zone.ien.utils.navigation.transition.fadeInOutPopTransitionSpec
-import kotlin.collections.listOf
 
 @Composable
 fun <T : NavKey> BaseNavDisplay(

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/InfScrollDetector.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/InfScrollDetector.kt
@@ -1,4 +1,4 @@
-package zone.ien.utils.firebase.firestore.utils
+package zone.ien.utils.ui.utils
 
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 agp = "9.0.0"
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 android-minSdk = "29"
-android-compileSdk = "36"
-android-targetSdk = "36"
+android-compileSdk = "37"
+android-targetSdk = "37"
 lib-version-name = "2.2.2"
 
 # plugin
 compose-plugin = "1.10.3"
 compose-plugin-experimental = "1.10.0-alpha05"
-compose-navigation3 = "1.0.0-alpha06"
+compose-navigation3 = "1.1.0"
 
 # firebase
 kmp-firebase = "2.4.0"
@@ -43,7 +43,7 @@ serialization = "1.11.0"
 runner = "1.7.0"
 coreVersion = "1.7.0"
 junit = "1.3.0"
-android-ui-graphics = "1.10.6"
+android-ui-graphics = "1.11.0"
 androidx-core = "1.18.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.21"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "2.2.2"
+lib-version-name = "2.2.3"
 
 # plugin
 compose-plugin = "1.10.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 agp = "9.0.0"
 kotlin = "2.3.21"
 android-minSdk = "29"
-android-compileSdk = "37"
-android-targetSdk = "37"
-lib-version-name = "2.2.3"
+android-compileSdk = "36"
+android-targetSdk = "36"
+lib-version-name = "2.2.4"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- InfScrollDetector를 cmp-firebase에서 cmp-ui 모듈로 이동하여 의존성을 정리합니다.
- 무한 스크롤 상태를 추상화한 InfScrollStateList 인터페이스를 cmp-common에 추가합니다.
- navigation3 1.1.0 버전에 맞춰 BaseNavDisplay에서 sceneStrategies 및 SharedTransitionScope를 지원하도록 수정합니다.
- Android SDK 37, Kotlin 2.3.21 등 주요 라이브러리 버전을 업데이트합니다.