### PR TITLE
♻️ refactor(dialog): 다이얼로그 콜백 널 허용 처리 및 버전 업데이트

### DIFF
--- a/cmp-adaptive/src/androidMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.android.kt
+++ b/cmp-adaptive/src/androidMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.android.kt
@@ -13,7 +13,7 @@ actual fun AlertDialog(
     message: String?,
     textDismiss: String,
     styleDismiss: UIAlertActionStyle,
-    onDismiss: () -> Unit
+    onDismiss: (() -> Unit)?
 ) {
     M3AlertDialog(
         modifier = modifier,

--- a/cmp-adaptive/src/androidMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.android.kt
+++ b/cmp-adaptive/src/androidMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.android.kt
@@ -8,13 +8,11 @@ import zone.ien.utils.ui.dialog.M3NetworkAlertDialog
 actual fun NetworkAlertDialog(
     modifier: Modifier,
     visible: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit
+    onDismiss: (() -> Unit)?,
 ) {
     M3NetworkAlertDialog(
         modifier = modifier,
         visible = visible,
         onDismiss = onDismiss,
-        onConfirm = onConfirm
     )
 }

--- a/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.kt
+++ b/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.kt
@@ -21,7 +21,7 @@ expect fun AlertDialog(
     message: String? = null,
     textDismiss: String = stringResource(Res.string.close),
     styleDismiss: UIAlertActionStyle = UIAlertActionStyle.Cancel,
-    onDismiss: () -> Unit,
+    onDismiss: (() -> Unit)?,
 )
 
 @Composable

--- a/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.kt
+++ b/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.kt
@@ -7,6 +7,5 @@ import androidx.compose.ui.Modifier
 expect fun NetworkAlertDialog(
     modifier: Modifier = Modifier,
     visible: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
+    onDismiss: (() -> Unit)?,
 )

--- a/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.ios.kt
+++ b/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.ios.kt
@@ -60,7 +60,7 @@ actual fun AlertDialog(
     message: String?,
     textDismiss: String,
     styleDismiss: UIAlertActionStyle,
-    onDismiss: () -> Unit
+    onDismiss: (() -> Unit)?
 ) {
     HigBaseAlertDialog(
         visible = visible,
@@ -71,7 +71,7 @@ actual fun AlertDialog(
             title = textDismiss,
             style = styleDismiss.toStyle(),
             handler = {
-                onDismiss()
+                onDismiss?.invoke()
             }
         )
 

--- a/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.ios.kt
+++ b/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/AlertDialog.ios.kt
@@ -67,15 +67,17 @@ actual fun AlertDialog(
         title = title,
         message = message
     ) { alertController ->
-        val dismissAction = UIAlertAction.actionWithTitle(
-            title = textDismiss,
-            style = styleDismiss.toStyle(),
-            handler = {
-                onDismiss?.invoke()
-            }
-        )
+        onDismiss?.let { callback ->
+            val dismissAction = UIAlertAction.actionWithTitle(
+                title = textDismiss,
+                style = styleDismiss.toStyle(),
+                handler = {
+                    callback()
+                }
+            )
+            alertController.addAction(dismissAction)
+        }
 
-        alertController.addAction(dismissAction)
     }
 }
 

--- a/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.ios.kt
+++ b/cmp-adaptive/src/iosMain/kotlin/zone/ien/utils/adaptive/dialog/NetworkAlertDialog.ios.kt
@@ -13,8 +13,7 @@ import zone.ien.utils.cmp_ui.generated.resources.retry
 actual fun NetworkAlertDialog(
     modifier: Modifier,
     visible: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit
+    onDismiss: (() -> Unit)?,
 ) {
     AlertDialog(
         modifier = modifier,
@@ -24,7 +23,5 @@ actual fun NetworkAlertDialog(
         message = stringResource(Res.string.network_dialog_content),
         textDismiss = stringResource(Res.string.close),
         onDismiss = onDismiss,
-        textConfirm = stringResource(Res.string.retry),
-        onConfirm = onConfirm
     )
 }

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/dialog/AlertDialog.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/dialog/AlertDialog.kt
@@ -53,7 +53,7 @@ fun M3AlertDialog(
     title: String?,
     message: String? = null,
     textDismiss: String = stringResource(Res.string.close),
-    onDismiss: () -> Unit,
+    onDismiss: (() -> Unit)?,
 ) {
     M3BaseAlertDialog(
         modifier = modifier,
@@ -61,13 +61,15 @@ fun M3AlertDialog(
         icon = icon,
         title = title,
         message = message,
-        onDismiss = onDismiss,
+        onDismiss = onDismiss ?: {},
         buttons = {
             Spacer(modifier = Modifier.weight(1f))
 
-            TextButton(
-                onClick = onDismiss,
-            ) { Text(text = textDismiss) }
+            onDismiss?.let {
+                TextButton(
+                    onClick = it,
+                ) { Text(text = textDismiss) }
+            }
         }
     )
 }

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/dialog/NetworkAlertDialog.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/dialog/NetworkAlertDialog.kt
@@ -15,8 +15,7 @@ import zone.ien.utils.icon.material.M3SystemIcons
 fun M3NetworkAlertDialog(
     modifier: Modifier = Modifier,
     visible: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
+    onDismiss: (() -> Unit)?,
 ) {
     M3AlertDialog(
         modifier = modifier,
@@ -26,7 +25,5 @@ fun M3NetworkAlertDialog(
         message = stringResource(Res.string.network_dialog_content),
         textDismiss = stringResource(Res.string.close),
         onDismiss = onDismiss,
-        textConfirm = stringResource(Res.string.retry),
-        onConfirm = onConfirm
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.21"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.2.5"
+lib-version-name = "2.2.6"
 
 # plugin
 compose-plugin = "1.10.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.21"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.2.6"
+lib-version-name = "2.3.0"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- AlertDialog의 onDismiss 파라미터를 nullable로 변경하여 선택적으로 버튼을 노출하도록 수정합니다.
- NetworkAlertDialog에서 불필요한 onConfirm 파라미터와 관련 로직을 제거하여 기능을 단순화합니다.
- gradle/libs.versions.toml의 lib-version-name을 2.2.5에서 2.2.6으로 업데이트합니다.