### PR TITLE
✨ feat(navigation): ResultStore 추가 및 버전 업데이트

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
@@ -1,12 +1,9 @@
 package zone.ien.utils.navigation.result
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
 
 @Stable
 class ResultStore {

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
@@ -1,0 +1,38 @@
+package zone.ien.utils.navigation.result
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Stable
+class ResultStore {
+    val results = mutableStateMapOf<String, Any?>() // MutableState 래핑 제거
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T> getResult(resultKey: String = T::class.toString()): T? {
+        return results[resultKey] as? T
+    }
+
+    inline fun <reified T> setResult(resultKey: String = T::class.toString(), result: T) {
+        results[resultKey] = result  // 직접 저장
+    }
+
+    inline fun <reified T> removeResult(resultKey: String = T::class.toString()) {
+        results.remove(resultKey)
+    }
+
+    inline fun <reified T> consumeResult(resultKey: String = T::class.toString()): T? {
+        val value = getResult<T>(resultKey)
+        removeResult<T>(resultKey)
+        return value
+    }
+}
+
+@Composable
+fun rememberResultStore(): ResultStore {
+    return remember { ResultStore() }  // rememberSaveable 제거
+}

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/result/ResultStore.kt
@@ -10,7 +10,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 
 @Stable
 class ResultStore {
-    val results = mutableStateMapOf<String, Any?>() // MutableState 래핑 제거
+    @PublishedApi
+    internal val results = mutableStateMapOf<String, Any?>()
 
     @Suppress("UNCHECKED_CAST")
     inline fun <reified T> getResult(resultKey: String = T::class.toString()): T? {

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
@@ -17,6 +17,7 @@ import zone.ien.utils.example.ui.screens.settings.SettingsScreen
 import zone.ien.utils.navigation.BaseNavDisplay
 import zone.ien.utils.navigation.getConfig
 import zone.ien.utils.navigation.navigateBack
+import zone.ien.utils.navigation.result.rememberResultStore
 
 @Serializable
 sealed interface RootRoute: NavKey {
@@ -32,13 +33,16 @@ fun RootNavigationGraph(
     modifier: Modifier = Modifier,
     backStack: NavBackStack<RootRoute>
 ) {
+    val resultStore = rememberResultStore()
+
     BaseNavDisplay(
         backStack = backStack,
         modifier = modifier,
         entryProvider = entryProvider {
             entry<RootRoute.Home> {
                 HomeScreen(
-                    backStack = backStack
+                    backStack = backStack,
+                    resultStore = resultStore
                 )
             }
             entry<RootRoute.Settings> {
@@ -53,7 +57,8 @@ fun RootNavigationGraph(
             }
             entry<RootRoute.Section> {
                 SectionScreen(
-                    navigateBack = { backStack.navigateBack() }
+                    navigateBack = { backStack.navigateBack() },
+                    resultStore = resultStore
                 )
             }
             entry<RootRoute.LazySection> {

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
@@ -52,13 +52,15 @@ import zone.ien.utils.ui.menu.ActionMenuItem
 import zone.ien.utils.ui.screen.TopBarSize
 import zone.ien.utils.icon.IconData
 import zone.ien.utils.icon.material.M3SystemIcons
+import zone.ien.utils.navigation.result.ResultStore
 import zone.ien.utils.ui.utils.conditional
 
 @OptIn(ExperimentalAdaptiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    backStack: NavBackStack<RootRoute>
+    backStack: NavBackStack<RootRoute>,
+    resultStore: ResultStore,
 ) {
     var isMaterialTheme by rememberSaveable { mutableStateOf(true) }
     var isDropdownMenu by remember { mutableStateOf(true) }
@@ -266,6 +268,9 @@ fun HomeScreen(
                         onCheckedChange = { isDropdownMenu = it }
                     )
                 }
+                Text(
+                    text = "result: ${resultStore.getResult<String>("text")}"
+                )
                 AnimatedVisibility(
                     visible = !isDropdownMenu,
                 ) {

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/section/SectionScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/section/SectionScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,10 +32,13 @@ import zone.ien.utils.adaptive.section.AdaptiveSection
 import zone.ien.utils.adaptive.section.AdaptiveSectionItem
 import zone.ien.utils.adaptive.section.AdaptiveSectionLink
 import zone.ien.utils.adaptive.section.AdaptiveSectionSwitchItem
+import zone.ien.utils.adaptive.section.AdaptiveSectionTextField
 import zone.ien.utils.adaptive.theme.GeneratedAdaptiveTheme
 import zone.ien.utils.example.Android
 import zone.ien.utils.example.isIos
 import zone.ien.utils.icon.IconData
+import zone.ien.utils.icon.material.M3SystemIcons
+import zone.ien.utils.navigation.result.ResultStore
 import zone.ien.utils.ui.menu.ActionMenuItem
 import zone.ien.utils.ui.section.M3ProvideSectionStyle
 
@@ -41,7 +46,8 @@ import zone.ien.utils.ui.section.M3ProvideSectionStyle
 @Composable
 fun SectionScreen(
     modifier: Modifier = Modifier,
-    navigateBack: () -> Unit
+    navigateBack: () -> Unit,
+    resultStore: ResultStore
 ) {
     val backdrop = rememberDefaultBackdrop()
     val scrollState = rememberScrollState()
@@ -110,6 +116,21 @@ fun SectionScreen(
                     AdaptiveSectionItem {
                         Text(text = "Section2")
                     }
+                    var text by remember { mutableStateOf("") }
+                    AdaptiveSectionTextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = { resultStore.setResult("text", text) }
+                            ) {
+                                Icon(
+                                    imageVector = M3SystemIcons.Save,
+                                    contentDescription = null
+                                )
+                            }
+                        }
+                    )
                     AdaptiveSectionLink(
                         onClick = {}
                     ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.3.21"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.3.0"
+lib-version-name = "2.4.0"
 
 # plugin
 compose-plugin = "1.10.3"


### PR DESCRIPTION
- 화면 간 데이터 전달 및 공유를 위한 `ResultStore` 클래스와 `rememberResultStore` 함수를 추가합니다.
- 예제 앱의 내비게이션 그래프와 각 화면(`HomeScreen`, `SectionScreen`)에 `ResultStore`를 전달하여 데이터 연동 기능을 구현합니다.
- `libs.versions.toml`의 `lib-version-name`을 2.3.0에서 2.4.0으로 업데이트합니다.

Closes #132 