### PR TITLE
✨ feat(ui): 상태 표시줄 스타일 설정 기능 추가

### DIFF
--- a/cmp-ui/build.gradle.kts
+++ b/cmp-ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.invoke
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
@@ -46,6 +48,7 @@ kotlin {
         }
 
         androidMain.dependencies {
+            implementation(libs.activity.compose)
         }
 
         getByName("androidDeviceTest").dependencies {

--- a/cmp-ui/src/androidMain/kotlin/zone/ien/utils/ui/utils/StatusBar.android.kt
+++ b/cmp-ui/src/androidMain/kotlin/zone/ien/utils/ui/utils/StatusBar.android.kt
@@ -14,15 +14,23 @@ actual fun setStatusBarStyle(isDarkTheme: Boolean): Boolean {
     val context = LocalContext.current
     val systemDarkTheme = isSystemInDarkTheme()
 
-    DisposableEffect(Unit) {
-        (context as ComponentActivity).enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT, detectDarkMode = { isDarkTheme }),
+    DisposableEffect(isDarkTheme) {
+        val activity = context as? ComponentActivity
+        activity?.enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(
+                Color.TRANSPARENT,
+                Color.TRANSPARENT,
+                detectDarkMode = { isDarkTheme }
+            )
         )
 
         onDispose {
-            context.enableEdgeToEdge(
-                statusBarStyle = systemDarkTheme.let { isDarkTheme -> SystemBarStyle.auto(
-                    Color.TRANSPARENT, Color.TRANSPARENT, detectDarkMode = { isDarkTheme }) },
+            activity?.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.auto(
+                    Color.TRANSPARENT,
+                    Color.TRANSPARENT,
+                    detectDarkMode = { systemDarkTheme }
+                )
             )
         }
     }

--- a/cmp-ui/src/androidMain/kotlin/zone/ien/utils/ui/utils/StatusBar.android.kt
+++ b/cmp-ui/src/androidMain/kotlin/zone/ien/utils/ui/utils/StatusBar.android.kt
@@ -1,0 +1,31 @@
+package zone.ien.utils.ui.utils
+
+import android.graphics.Color
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun setStatusBarStyle(isDarkTheme: Boolean): Boolean {
+    val context = LocalContext.current
+    val systemDarkTheme = isSystemInDarkTheme()
+
+    DisposableEffect(Unit) {
+        (context as ComponentActivity).enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT, detectDarkMode = { isDarkTheme }),
+        )
+
+        onDispose {
+            context.enableEdgeToEdge(
+                statusBarStyle = systemDarkTheme.let { isDarkTheme -> SystemBarStyle.auto(
+                    Color.TRANSPARENT, Color.TRANSPARENT, detectDarkMode = { isDarkTheme }) },
+            )
+        }
+    }
+
+    return true
+}

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/StatusBar.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/StatusBar.kt
@@ -1,7 +1,6 @@
 package zone.ien.utils.ui.utils
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 
 @Composable
 expect fun setStatusBarStyle(

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/StatusBar.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/utils/StatusBar.kt
@@ -1,0 +1,9 @@
+package zone.ien.utils.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun setStatusBarStyle(
+    isDarkTheme: Boolean
+): Boolean

--- a/cmp-ui/src/iosMain/kotlin/zone/ien/utils/ui/utils/StatusBar.ios.kt
+++ b/cmp-ui/src/iosMain/kotlin/zone/ien/utils/ui/utils/StatusBar.ios.kt
@@ -1,0 +1,6 @@
+package zone.ien.utils.ui.utils
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun setStatusBarStyle(isDarkTheme: Boolean) = true


### PR DESCRIPTION
- Android, iOS, 공통 플랫폼에 대해 상태 표시줄 스타일을 설정하는 기능 구현
- Dark theme에 따른 상태 표시줄 색상 변경 로직 추가
- build.gradle.kts 파일에서 플러그인 및 의존성 정의 수정