### PR TITLE
docs(filekit): add comprehensive comments to all files

### DIFF
--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Data.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Data.android.kt
@@ -2,4 +2,8 @@ package zone.ien.utils.filekit
 
 import dev.gitlive.firebase.storage.Data
 
+/**
+ * 바이트 배열을 Firebase Storage 데이터로 변환합니다.
+ * @return Firebase Storage Data 객체
+ */
 actual suspend fun ByteArray.toStorageData(): Data = Data(this)

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
@@ -25,7 +25,7 @@ actual fun getFile(path: String): File {
 }
 
 /**
- * File을 파일 경로 문자열로 변환합니다.
- * @return 파일 경로 문자열
+ * File 객체를 URI 문자열로 변환합니다.
+ * @return 파일의 URI 문자열
  */
 actual fun File.toPath(): String = uri.toString()

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
@@ -5,14 +5,27 @@ import dev.gitlive.firebase.storage.File
 import io.github.vinceglb.filekit.AndroidFile
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * PlatformFile을 Android File 객체로 변환합니다.
+ * @return 변환된 File 객체 또는 null (변환 실패 시)
+ */
 actual fun PlatformFile.toFile(): File? {
     val file = androidFile
     return if (file is AndroidFile.UriWrapper) File(file.uri) else null
 }
 
+/**
+ * 지정된 경로의 파일을 가져옵니다.
+ * @param path 파일 경로
+ * @return File 객체
+ */
 actual fun getFile(path: String): File {
     val uri = Uri.fromFile(java.io.File(path))
     return File(uri)
 }
 
+/**
+ * File을 파일 경로 문자열로 변환합니다.
+ * @return 파일 경로 문자열
+ */
 actual fun File.toPath(): String = uri.toString()

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Storage.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Storage.android.kt
@@ -4,6 +4,11 @@ import dev.gitlive.firebase.storage.FirebaseStorageMetadata
 import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * Firebase Storage에 파일을 업로드합니다.
+ * @param file 업로드할 PlatformFile
+ * @param metadata 파일 메타데이터 (옵션)
+ */
 actual suspend fun StorageReference.uploadFile(file: PlatformFile, metadata: FirebaseStorageMetadata?) {
     file.toFile()?.let { putFile(it, metadata) }
 }

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Uri.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Uri.android.kt
@@ -3,6 +3,10 @@ package zone.ien.utils.filekit
 import io.github.vinceglb.filekit.AndroidFile
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * PlatformFile에서 URI 문자열을 얻습니다.
+ * @return 파일의 URI 문자열
+ */
 actual fun PlatformFile.getUri(): String {
     val file = androidFile
     return if (file is AndroidFile.UriWrapper) file.uri.toString() else ""

--- a/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/File.apple.kt
+++ b/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/File.apple.kt
@@ -5,15 +5,28 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.path
 import platform.Foundation.NSURL
 
+/**
+ * PlatformFile을 Apple File 객체로 변환합니다.
+ * @return 변환된 File 객체 또는 null (변환 실패 시)
+ */
 actual fun PlatformFile.toFile(): File? {
     val url = NSURL(fileURLWithPath = this.path)
     val file = File(url)
     return file
 }
 
+/**
+ * 지정된 경로의 파일을 가져옵니다.
+ * @param path 파일 경로
+ * @return File 객체
+ */
 actual fun getFile(path: String): File {
     val url = NSURL(fileURLWithPath = path)
     return File(url)
 }
 
+/**
+ * File을 파일 경로 문자열로 변환합니다.
+ * @return 파일 경로 문자열
+ */
 actual fun File.toPath(): String = url.path.orEmpty()

--- a/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Storage.apple.kt
+++ b/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Storage.apple.kt
@@ -4,6 +4,11 @@ import dev.gitlive.firebase.storage.FirebaseStorageMetadata
 import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * Firebase Storage에 파일을 업로드합니다.
+ * @param file 업로드할 PlatformFile
+ * @param metadata 파일 메타데이터 (옵션)
+ */
 actual suspend fun StorageReference.uploadFile(file: PlatformFile, metadata: FirebaseStorageMetadata?) {
     val f = file.toFile() ?: return
 

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Data.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Data.kt
@@ -2,4 +2,8 @@ package zone.ien.utils.filekit
 
 import dev.gitlive.firebase.storage.Data
 
+/**
+ * 바이트 배열을 Firebase Storage 데이터로 변환하는 예상 함수
+ * @return Firebase Storage Data 객체
+ */
 expect suspend fun ByteArray.toStorageData(): Data

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
@@ -28,9 +28,9 @@ expect fun File.toPath(): String
 
 
 /**
- * PlatformFile을 지정된 크기로 압축하는 함수
- * @param targetSize 압축 후 목표 크기 (bytes)
- * @return 압축된 바이트 배열 또는 null (압축 실패 시)
+ * 이미지(PlatformFile)를 지정된 크기 이하로 압축하는 함수입니다.
+ * @param targetSize 압축 후 목표로 하는 최대 크기 (Byte 단위)
+ * @return 압축된 바이트 배열 또는 파일 읽기 실패 시 null
  */
 private const val QUALITY_STEP = 5
 suspend fun PlatformFile.compressFile(targetSize: Long): ByteArray? {

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
@@ -7,14 +7,34 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.compressImage
 import io.github.vinceglb.filekit.readBytes
 
+/**
+ * PlatformFile을 파일로 변환하는 예상 함수
+ * @return 변환된 File 객체 또는 null
+ */
 expect fun PlatformFile.toFile(): File?
+
+/**
+ * 파일 경로를 사용하여 파일 객체를 얻는 예상 함수
+ * @param path 파일 경로
+ * @return 파일 객체
+ */
 expect fun getFile(path: String): File
+
+/**
+ * File을 파일 경로로 변환하는 예상 함수
+ * @return 파일 경로 문자열
+ */
 expect fun File.toPath(): String
 
 
+/**
+ * PlatformFile을 지정된 크기로 압축하는 함수
+ * @param targetSize 압축 후 목표 크기 (bytes)
+ * @return 압축된 바이트 배열 또는 null (압축 실패 시)
+ */
 private const val QUALITY_STEP = 5
 suspend fun PlatformFile.compressFile(targetSize: Long): ByteArray? {
-// 1. 원본 이미지 데이터 읽기
+    // 1. 원본 이미지 데이터 읽기
     val originalBytes = try {
         readBytes()
     } catch (e: Exception) {

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
@@ -8,7 +8,7 @@ import io.github.vinceglb.filekit.compressImage
 import io.github.vinceglb.filekit.readBytes
 
 /**
- * PlatformFile을 파일로 변환하는 예상 함수
+ * PlatformFile을 파일 객체로 변환하는 Expect 함수입니다.
  * @return 변환된 File 객체 또는 null
  */
 expect fun PlatformFile.toFile(): File?

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Storage.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Storage.kt
@@ -5,4 +5,9 @@ import dev.gitlive.firebase.storage.FirebaseStorageMetadata
 import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * Firebase Storage에 파일을 업로드하는 예상 함수
+ * @param file 업로드할 PlatformFile
+ * @param metadata 파일 메타데이터 (옵션)
+ */
 expect suspend fun StorageReference.uploadFile(file: PlatformFile, metadata: FirebaseStorageMetadata? = null)

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Uri.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Uri.kt
@@ -2,4 +2,8 @@ package zone.ien.utils.filekit
 
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * PlatformFile에서 URI 문자열을 얻는 예상 함수
+ * @return 파일의 URI 문자열
+ */
 expect fun PlatformFile.getUri(): String

--- a/cmp-filekit/src/iosMain/kotlin/zone/ien/utils/filekit/Uri.ios.kt
+++ b/cmp-filekit/src/iosMain/kotlin/zone/ien/utils/filekit/Uri.ios.kt
@@ -2,4 +2,8 @@ package zone.ien.utils.filekit
 
 import io.github.vinceglb.filekit.PlatformFile
 
+/**
+ * PlatformFile에서 URI 문자열을 얻습니다.
+ * @return 파일의 URI 문자열
+ */
 actual fun PlatformFile.getUri(): String = nsUrl.toString()


### PR DESCRIPTION
This commit adds comprehensive comments and documentation to the filekit module files including:
- Added detailed comments to all common platform files (File.kt, Storage.kt, Uri.kt, Data.kt)
- Added comments to Android platform specific files (File.android.kt, Storage.android.kt, Uri.android.kt, Data.android.kt)
- Added comments to Apple platform specific files (File.apple.kt, Storage.apple.kt)
- Added comments to iOS specific files (Uri.ios.kt)
- The comments explain function purpose, parameters, and return values
- This improves code readability and maintainability
모든 문서화는 한국어로, 라이브러리 사용자가 접근 가능한 모든 메소드와 클래스에 대하여 이루어져야 한다.
Closes #158 