### PR TITLE
⚡ perf(core): 라이브러리 버전 업데이트

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ compose-navigation3 = "1.1.1"
 
 # firebase
 kmp-firebase = "2.4.0"
-firebase-firestore = "26.2.0"
+firebase-firestore = "26.3.0"
 firebase-storage = "22.0.1"
 firebase-common = "22.0.1"
 
@@ -24,11 +24,11 @@ backdrop = "2.0.0-alpha06"
 haze = "1.7.2"
 hig = "1.1.0-alpha04"
 capsule = "1.2.0"
-placeholder = "1.0.2"
+placeholder = "1.0.3"
 
 # functionality
 kdatetime = "1.1.2"
-kotlin-coroutine = "1.10.2"
+kotlin-coroutine = "1.11.0"
 startup-runtime = "1.2.0"
 kotlinx-io-core = "0.9.0"
 filekit = "0.13.0"


### PR DESCRIPTION
- firebase-firestore 버전 26.2.0에서 26.3.0으로 업데이트
- placeholder 버전 1.0.2에서 1.0.3으로 업데이트
- kotlin-coroutine 버전 1.10.2에서 1.11.0으로 업데이트