### PR TITLE
✨ feat(ui): enableNativeInput 함수 추가 및 버전 업데이트

### DIFF
--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
@@ -1,5 +1,6 @@
 package zone.ien.utils.utils.ui
 
 import androidx.compose.foundation.text.KeyboardOptions
+
 // Android does not require additional configuration for native input.
 actual fun KeyboardOptions.enableNativeInput(): KeyboardOptions = this

--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
@@ -1,7 +1,5 @@
 package zone.ien.utils.utils.ui
 
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.ExperimentalComposeUiApi
-
-@OptIn(ExperimentalComposeUiApi::class)
-actual fun KeyboardOptions.enableNativeInput() = this
+// Android does not require additional configuration for native input.
+actual fun KeyboardOptions.enableNativeInput(): KeyboardOptions = this

--- a/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
+++ b/cmp-utils/src/androidMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.android.kt
@@ -1,0 +1,7 @@
+package zone.ien.utils.utils.ui
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.ExperimentalComposeUiApi
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun KeyboardOptions.enableNativeInput() = this

--- a/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.kt
+++ b/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.kt
@@ -2,4 +2,11 @@ package zone.ien.utils.utils.ui
 
 import androidx.compose.foundation.text.KeyboardOptions
 
+/**
+ * 플랫폼별 네이티브 입력 기능을 활성화합니다.
+ *
+ * iOS 플랫폼에서는 네이티브 텍스트 입력 핸들링을 활성화하며, 그 외 플랫폼에서는 현재 설정을 그대로 반환합니다.
+ *
+ * @return 네이티브 입력이 활성화된 [KeyboardOptions]
+ */
 expect fun KeyboardOptions.enableNativeInput(): KeyboardOptions

--- a/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.kt
+++ b/cmp-utils/src/commonMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.kt
@@ -1,0 +1,5 @@
+package zone.ien.utils.utils.ui
+
+import androidx.compose.foundation.text.KeyboardOptions
+
+expect fun KeyboardOptions.enableNativeInput(): KeyboardOptions

--- a/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.ios.kt
+++ b/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.ios.kt
@@ -1,0 +1,15 @@
+package zone.ien.utils.utils.ui
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.text.input.PlatformImeOptions
+
+/**
+ * Enables native input for keyboard options on iOS.
+ *
+ * This function enables native input handling for iOS platforms.
+ *
+ * @return The [KeyboardOptions] with native input enabled
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun KeyboardOptions.enableNativeInput() = copy(platformImeOptions = PlatformImeOptions { usingNativeTextInput(true) })

--- a/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.ios.kt
+++ b/cmp-utils/src/iosMain/kotlin/zone/ien/utils/utils/ui/enableNativeInput.ios.kt
@@ -4,12 +4,5 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.text.input.PlatformImeOptions
 
-/**
- * Enables native input for keyboard options on iOS.
- *
- * This function enables native input handling for iOS platforms.
- *
- * @return The [KeyboardOptions] with native input enabled
- */
 @OptIn(ExperimentalComposeUiApi::class)
 actual fun KeyboardOptions.enableNativeInput() = copy(platformImeOptions = PlatformImeOptions { usingNativeTextInput(true) })

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +14,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBar
@@ -61,6 +65,7 @@ import zone.ien.utils.navigation.result.ResultStore
 import zone.ien.utils.ui.utils.conditional
 import zone.ien.utils.utils.moveToBackground
 import zone.ien.utils.utils.shareText
+import zone.ien.utils.utils.ui.enableNativeInput
 import zone.ien.utils.utils.ui.rememberRepeatClick
 
 @OptIn(ExperimentalAdaptiveApi::class, ExperimentalMaterial3Api::class)
@@ -414,8 +419,37 @@ fun HomeScreen(
                 }
                 TextField(
                     state = rememberTextFieldState(),
+                    keyboardOptions = KeyboardOptions.Default.enableNativeInput(),
                     modifier = Modifier.fillMaxWidth()
                 )
+                TextField(
+                    state = rememberTextFieldState(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                BasicTextField(
+                    state = rememberTextFieldState(),
+                    keyboardOptions = KeyboardOptions.Default.enableNativeInput(),
+                    decorator = TextFieldDecorator { innerTextField ->
+                        Box(
+                            modifier = Modifier.background(Color.Yellow)
+                        ) {
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                BasicTextField(
+                    state = rememberTextFieldState(),
+                    decorator = TextFieldDecorator { innerTextField ->
+                        Box(
+                            modifier = Modifier.background(Color.Yellow)
+                        ) {
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(96.dp))
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ firebase-common = "22.0.1"
 
 # ui
 activity-compose = "1.13.0"
-lifecycle = "2.10.0"
+lifecycle = "2.11.0-beta01"
 backdrop = "2.0.0-alpha06"
 haze = "1.7.2"
 hig = "1.1.0-alpha04"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,10 @@ kotlin = "2.3.21"
 android-minSdk = "29"
 android-compileSdk = "36"
 android-targetSdk = "36"
-lib-version-name = "2.8.0"
+lib-version-name = "2.9.0"
 
 # plugin
-compose-plugin = "1.11.0-rc01"
+compose-plugin = "1.11.0"
 compose-plugin-experimental = "1.11.0-alpha07"
 compose-navigation3 = "1.1.1"
 


### PR DESCRIPTION
- 공통 모듈에 enableNativeInput 함수 정의 추가
- 안드로이드 및 iOS 플랫폼별 구현 추가
- 예제 앱에서 키보드 옵션 사용법 업데이트
- 라이브러리 버전 2.8.0에서 2.9.0으로 업데이트
- Compose plugin 버전 1.11.0-rc01에서 1.11.0으로 변경