### PR TITLE
✨ feat(navigation): 백스택 조작 유틸리티 함수 추가 및 Snapshot 트랜잭션 적용

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
@@ -1,5 +1,6 @@
 package zone.ien.utils.navigation
 
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.savedstate.serialization.SavedStateConfiguration
@@ -8,20 +9,29 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 
 /**
- * 백스택에서 마지막 요소를 제거하고 반환하는 함수
+ * 백스택의 마지막 요소를 제거하고 반환합니다.
+ *
  * @return 제거된 요소
+ * @throws IllegalStateException 백스택이 비어 있는 경우
  */
-fun <T: NavKey> NavBackStack<T>.navigateBack(): T {
+fun <T : NavKey> NavBackStack<T>.navigateBack(): T {
+    check(isNotEmpty()) {
+        "비어 있는 백스택에서는 뒤로 이동할 수 없습니다."
+    }
+
     return removeAt(lastIndex)
 }
 
 /**
- * 뒤로가기 처리 함수
- * 백스택에 요소가 있을 경우 이전 화면으로 이동하고, 없을 경우 back 콜백 호출
- * @param back 뒤로가기 처리 시 호출할 콜백 함수
+ * 뒤로가기를 처리합니다.
+ *
+ * 백스택에 이전 화면이 있으면 마지막 요소를 제거하고,
+ * 루트 화면이라면 [back]을 호출합니다.
+ *
+ * @param back 루트 화면에서 호출할 플랫폼 뒤로가기 콜백
  */
-fun <T: NavKey> NavBackStack<T>.onBackPressed(
-    back: () -> Unit
+fun <T : NavKey> NavBackStack<T>.onBackPressed(
+    back: () -> Unit,
 ) {
     if (size > 1) {
         navigateBack()
@@ -31,15 +41,91 @@ fun <T: NavKey> NavBackStack<T>.onBackPressed(
 }
 
 /**
- * 지정된 라우트까지 백스택을 pop-up 처리하는 함수
- * @param route 백스택에서 제거할 라우트
- * @param inclusive 포함 여부 (기본값은 false)
+ * 지정한 Route까지 백스택을 제거합니다.
+ *
+ * 같은 Route가 여러 개 존재하면 현재 위치에서 가장 가까운 Route를 기준으로 합니다.
+ *
+ * @param route 이동할 Route
+ * @param inclusive true이면 지정한 Route도 함께 제거합니다.
+ * @return 지정한 Route를 찾았는지 여부
  */
-fun <T: NavKey> NavBackStack<T>.popUpTo(route: T, inclusive: Boolean = false) {
-    val bIndex = indexOfFirst { it == route }
-    if (bIndex != -1) {
-        val popCount = if (inclusive) size - bIndex else size - bIndex - 1
-        repeat(popCount) { navigateBack() }
+fun <T : NavKey> NavBackStack<T>.popUpTo(
+    route: T,
+    inclusive: Boolean = false,
+): Boolean {
+    val targetIndex = indexOfLast { it == route }
+
+    if (targetIndex == -1) {
+        return false
+    }
+
+    val destinationIndex = if (inclusive) {
+        targetIndex - 1
+    } else {
+        targetIndex
+    }
+
+    Snapshot.withMutableSnapshot {
+        while (lastIndex > destinationIndex) {
+            removeAt(lastIndex)
+        }
+    }
+
+    return true
+}
+
+/**
+ * 현재 화면을 새 Route로 교체합니다.
+ */
+fun <T : NavKey> NavBackStack<T>.replaceTop(
+    route: T,
+) {
+    Snapshot.withMutableSnapshot {
+        if (isEmpty()) {
+            add(route)
+        } else {
+            this[lastIndex] = route
+        }
+    }
+}
+
+/**
+ * 기존 백스택을 모두 제거하고 지정한 Route부터 다시 시작합니다.
+ *
+ * 로그인 완료나 로그아웃처럼 이전 화면으로 돌아가면 안 되는 전환에 사용합니다.
+ */
+fun <T : NavKey> NavBackStack<T>.resetTo(
+    route: T,
+) {
+    Snapshot.withMutableSnapshot {
+        clear()
+        add(route)
+    }
+}
+
+/**
+ * 현재 최상단 Route와 다를 때만 새 Route를 추가합니다.
+ */
+fun <T : NavKey> NavBackStack<T>.navigateSingleTop(
+    route: T,
+) {
+    if (lastOrNull() != route) {
+        add(route)
+    }
+}
+
+/**
+ * 첫 번째 Route만 남기고 모두 제거합니다.
+ */
+fun <T : NavKey> NavBackStack<T>.popUpToRoot() {
+    if (size <= 1) {
+        return
+    }
+
+    Snapshot.withMutableSnapshot {
+        while (size > 1) {
+            removeAt(lastIndex)
+        }
     }
 }
 

--- a/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
+++ b/cmp-navigation/src/commonMain/kotlin/zone/ien/utils/navigation/Utils.kt
@@ -15,11 +15,12 @@ import kotlinx.serialization.modules.polymorphic
  * @throws IllegalStateException 백스택이 비어 있는 경우
  */
 fun <T : NavKey> NavBackStack<T>.navigateBack(): T {
-    check(isNotEmpty()) {
-        "비어 있는 백스택에서는 뒤로 이동할 수 없습니다."
+    return Snapshot.withMutableSnapshot {
+        check(isNotEmpty()) {
+            "비어 있는 백스택에서는 뒤로 이동할 수 없습니다."
+        }
+        removeAt(lastIndex)
     }
-
-    return removeAt(lastIndex)
 }
 
 /**
@@ -53,25 +54,25 @@ fun <T : NavKey> NavBackStack<T>.popUpTo(
     route: T,
     inclusive: Boolean = false,
 ): Boolean {
-    val targetIndex = indexOfLast { it == route }
+    return Snapshot.withMutableSnapshot {
+        val targetIndex = indexOfLast { it == route }
 
-    if (targetIndex == -1) {
-        return false
-    }
+        if (targetIndex == -1) {
+            return@withMutableSnapshot false
+        }
 
-    val destinationIndex = if (inclusive) {
-        targetIndex - 1
-    } else {
-        targetIndex
-    }
+        val destinationIndex = if (inclusive) {
+            targetIndex - 1
+        } else {
+            targetIndex
+        }
 
-    Snapshot.withMutableSnapshot {
         while (lastIndex > destinationIndex) {
             removeAt(lastIndex)
         }
-    }
 
-    return true
+        true
+    }
 }
 
 /**
@@ -109,8 +110,10 @@ fun <T : NavKey> NavBackStack<T>.resetTo(
 fun <T : NavKey> NavBackStack<T>.navigateSingleTop(
     route: T,
 ) {
-    if (lastOrNull() != route) {
-        add(route)
+    Snapshot.withMutableSnapshot {
+        if (lastOrNull() != route) {
+            add(route)
+        }
     }
 }
 
@@ -118,11 +121,11 @@ fun <T : NavKey> NavBackStack<T>.navigateSingleTop(
  * 첫 번째 Route만 남기고 모두 제거합니다.
  */
 fun <T : NavKey> NavBackStack<T>.popUpToRoot() {
-    if (size <= 1) {
-        return
-    }
-
     Snapshot.withMutableSnapshot {
+        if (size <= 1) {
+            return@withMutableSnapshot
+        }
+
         while (size > 1) {
             removeAt(lastIndex)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.4.10"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.0.0"
+lib-version-name = "3.0.1"
 
 # plugin
 compose-plugin = "1.11.1"


### PR DESCRIPTION
## 요약
NavBackStack 조작을 위한 신규 유틸리티 함수를 추가하고, 백스택 변경 시 발생할 수 있는 중간 재구성(Recomposition)을 방지하기 위해 Compose Snapshot 트랜잭션을 적용했습니다.

## 주요 변경사항
- `replaceTop`, `resetTo`, `navigateSingleTop`, `popUpToRoot` 유틸리티 함수 추가
- `popUpTo` 함수 검색 방식을 `indexOfLast`로 변경하여 가장 최근 라우트 기준으로 pop 처리
- `popUpTo`, `replaceTop`, `resetTo`, `popUpToRoot` 연산에 `Snapshot.withMutableSnapshot` 적용
- `navigateBack` 호출 시 백스택 비어있음 여부 사전 검증 (`check(isNotEmpty())`) 추가
- 라이브러리 버전을 3.0.1로 업데이트

## 확인 사항
- Compose Navigation 백스택 연산 시 원자적 상태 변경 및 예외 처리 동작 확인
- Gradle 메타데이터 컴파일 검증 완료

## 영향 범위
- Navigation 모듈 (`cmp-navigation`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation options to replace the current destination, reset navigation, prevent duplicate destinations, and return to the root destination.
  * Back stack navigation now reports whether a requested destination was found.
* **Bug Fixes**
  * Improved back navigation safety when the navigation stack is empty.
  * Improved consistency when updating navigation history.
* **Chores**
  * Updated the library version to 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->