### PR TITLE
♻️ refactor(firebase): Firebase 라이브러리 이관 및 Git 브랜치 전략 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,78 @@ Please find the detailed guide [here](https://www.jetbrains.com/help/kotlin-mult
 # Other resources
 * [Publishing via the Central Portal](https://central.sonatype.org/publish-ea/publish-ea-guide/)
 * [Gradle Maven Publish Plugin \- Publishing to Maven Central](https://vanniktech.github.io/gradle-maven-publish-plugin/central/)
+
+
+---
+
+## 🌿 Git 브랜치 전략 & 커밋 메시지 규칙
+
+### 브랜치 토폴로지 (Branch Topology)
+```text
+main ← dev ← feature/*
+hotfix/* → main → dev
+```
+
+### 브랜치 역할
+- **main**: 항상 배포 가능한 상태를 유지합니다. 직접 `push`가 금지되며 PR을 통해서만 변경사항을 병합합니다.
+- **dev**: 개발 통합 브랜치입니다. 모든 `feature/*` 브랜치는 최신 `dev`에서 분기합니다.
+- **feature/***: 새로운 기능이나 일반 개발 작업에 사용합니다. 최신 `dev`에서 생성하고 작업 완료 후 `dev`로 PR을 생성합니다.
+- **hotfix/***: 배포된 버전의 긴급 수정에 사용합니다. `main`에서 분기하며 수정 완료 후 `main`으로 병합합니다. `main` 병합 직후 변경 사항을 반드시 `dev`로 역동기화합니다.
+
+### 머지 방식 (Merge Strategy)
+| 방향 | GitHub 머지 방식 |
+| --- | --- |
+| `feature/* → dev` | Squash and merge |
+| `dev → main` | Create a merge commit |
+| `hotfix/* → main` | Create a merge commit |
+| `main → dev` | Create a merge commit |
+
+### main → dev 역동기화 규칙
+`main`에 릴리스 또는 핫픽스 변경이 병합되면 즉시 `main → dev` 역동기화를 진행해야 합니다.
+
+---
+
+### 커밋 메시지 규칙
+
+커밋 메시지는 다음 형식만 허용됩니다.
+
+```text
+<이모지> <타입>: <설명>
+```
+
+#### 허용 정규식
+```regex
+^(✨ feat|🐛 fix|📝 docs|💄 style|♻️ refactor|✅ test|🔧 chore|⚡ perf|👷 ci): .+$
+```
+
+#### 허용 타입 및 이모지
+| 이모지 | 타입 | 용도 |
+| :---: | :--- | :--- |
+| ✨ | `feat` | 새로운 기능 |
+| 🐛 | `fix` | 버그 수정 |
+| 📝 | `docs` | 문서 변경 |
+| 💄 | `style` | 코드 동작 변화 없는 포맷 또는 UI 스타일 변경 |
+| ♻️ | `refactor` | 동작 변화 없는 코드 구조 개선 |
+| ✅ | `test` | 테스트 추가 및 수정 |
+| 🔧 | `chore` | 의존성, 설정, 유지보수 작업 |
+| ⚡ | `perf` | 성능 개선 |
+| 👷 | `ci` | CI/CD 설정 변경 |
+
+#### 예시
+- **유효한 예:**
+  - `✨ feat: 음성 재료 추가 기능 구현`
+  - `🐛 fix: 타이머가 초기화되지 않는 문제 수정`
+- **유효하지 않은 예:**
+  - `feat: 기능 추가` (이모지 누락)
+  - `✨ 기능: 기능 추가` (타입 오류)
+  - `fix 버그 수정` (`:` 구분자 누락)
+  - `🐛 fix:` (설명 누락)
+
+### 커밋 메시지 검증 (Git Hooks)
+프로젝트 내 `.githooks/commit-msg` Hook이 구성되어 있습니다. 아래 명령을 실행하여 커밋 메시지 검증 Hook을 활성화할 수 있습니다.
+
+```bash
+git config core.hooksPath .githooks
+# 또는 Gradle Task 실행
+./gradlew installGitHooks
+```

--- a/README.md
+++ b/README.md
@@ -84,11 +84,3 @@ hotfix/* → main → dev
   - `fix 버그 수정` (`:` 구분자 누락)
   - `🐛 fix:` (설명 누락)
 
-### 커밋 메시지 검증 (Git Hooks)
-프로젝트 내 `.githooks/commit-msg` Hook이 구성되어 있습니다. 아래 명령을 실행하여 커밋 메시지 검증 Hook을 활성화할 수 있습니다.
-
-```bash
-git config core.hooksPath .githooks
-# 또는 Gradle Task 실행
-./gradlew installGitHooks
-```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,3 +55,9 @@ subprojects {
         }
     }
 }
+
+tasks.register<Exec>("installGitHooks") {
+    description = "Installs git hooks from .githooks directory."
+    group = "build setup"
+    commandLine("git", "config", "core.hooksPath", ".githooks")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,9 +55,3 @@ subprojects {
         }
     }
 }
-
-tasks.register<Exec>("installGitHooks") {
-    description = "Installs git hooks from .githooks directory."
-    group = "build setup"
-    commandLine("git", "config", "core.hooksPath", ".githooks")
-}

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Data.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Data.android.kt
@@ -1,6 +1,6 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.Data
+import zone.ien.firebase.storage.Data
 
 /**
  * 바이트 배열을 Firebase Storage 데이터로 변환합니다.

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/File.android.kt
@@ -1,9 +1,9 @@
 package zone.ien.utils.filekit
 
 import android.net.Uri
-import dev.gitlive.firebase.storage.File
 import io.github.vinceglb.filekit.AndroidFile
 import io.github.vinceglb.filekit.PlatformFile
+import zone.ien.firebase.storage.File
 
 /**
  * PlatformFile을 Android File 객체로 변환합니다.

--- a/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Storage.android.kt
+++ b/cmp-filekit/src/androidMain/kotlin/zone/ien/utils/filekit/Storage.android.kt
@@ -1,8 +1,8 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.FirebaseStorageMetadata
-import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
+import zone.ien.firebase.storage.FirebaseStorageMetadata
+import zone.ien.firebase.storage.StorageReference
 
 /**
  * Firebase Storage에 파일을 업로드합니다.

--- a/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Data.apple.kt
+++ b/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Data.apple.kt
@@ -1,12 +1,12 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.Data
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.create
+import zone.ien.firebase.storage.Data
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 actual suspend fun ByteArray.toStorageData(): Data {

--- a/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/File.apple.kt
+++ b/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/File.apple.kt
@@ -1,9 +1,9 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.File
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.path
 import platform.Foundation.NSURL
+import zone.ien.firebase.storage.File
 
 /**
  * PlatformFile을 Apple File 객체로 변환합니다.

--- a/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Storage.apple.kt
+++ b/cmp-filekit/src/appleMain/kotlin/zone/ien/utils/filekit/Storage.apple.kt
@@ -1,8 +1,8 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.FirebaseStorageMetadata
-import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
+import zone.ien.firebase.storage.FirebaseStorageMetadata
+import zone.ien.firebase.storage.StorageReference
 
 /**
  * Firebase Storage에 파일을 업로드합니다.

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Data.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Data.kt
@@ -1,6 +1,6 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.Data
+import zone.ien.firebase.storage.Data
 
 /**
  * 바이트 배열을 Firebase Storage 데이터로 변환하는 예상 함수

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/File.kt
@@ -1,11 +1,11 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.File
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.ImageFormat
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.compressImage
 import io.github.vinceglb.filekit.readBytes
+import zone.ien.firebase.storage.File
 
 /**
  * PlatformFile을 파일 객체로 변환하는 Expect 함수입니다.

--- a/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Storage.kt
+++ b/cmp-filekit/src/commonMain/kotlin/zone/ien/utils/filekit/Storage.kt
@@ -1,9 +1,8 @@
 package zone.ien.utils.filekit
 
-import dev.gitlive.firebase.storage.Data
-import dev.gitlive.firebase.storage.FirebaseStorageMetadata
-import dev.gitlive.firebase.storage.StorageReference
 import io.github.vinceglb.filekit.PlatformFile
+import zone.ien.firebase.storage.FirebaseStorageMetadata
+import zone.ien.firebase.storage.StorageReference
 
 /**
  * Firebase Storage에 파일을 업로드하는 예상 함수

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/model/FirestoreItem.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/model/FirestoreItem.kt
@@ -1,7 +1,7 @@
 package zone.ien.utils.firebase.firestore.model
 
 import com.sunnychung.lib.multiplatform.kdatetime.KZonedDateTime
-import dev.gitlive.firebase.firestore.DocumentReference
+import zone.ien.firebase.firestore.DocumentReference
 
 interface BaseFirestoreItem {
     /**

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/model/InfScrollStateList.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/model/InfScrollStateList.kt
@@ -1,6 +1,6 @@
 package zone.ien.utils.firebase.firestore.model
 
-import dev.gitlive.firebase.firestore.DocumentSnapshot
+import zone.ien.firebase.firestore.DocumentSnapshot
 
 /**
  * 무한 스크롤 상태 리스트 인터페이스

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Collection.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Collection.kt
@@ -1,8 +1,11 @@
 package zone.ien.utils.firebase.firestore.utils
 
-import dev.gitlive.firebase.firestore.CollectionReference
-import dev.gitlive.firebase.firestore.Query
 import kotlinx.coroutines.flow.filter
+import zone.ien.firebase.firestore.CollectionReference
+import zone.ien.firebase.firestore.Query
+import zone.ien.firebase.firestore.metadata
+import zone.ien.firebase.firestore.snapshots
+
 
 /**
  * CollectionReference에서 스냅샷을 구독하는 함수

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Deletion.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Deletion.kt
@@ -1,7 +1,8 @@
 package zone.ien.utils.firebase.firestore.utils
 
-import dev.gitlive.firebase.firestore.DocumentReference
-import dev.gitlive.firebase.firestore.FieldValue
+import zone.ien.firebase.firestore.DocumentReference
+import zone.ien.firebase.firestore.FieldValue
+
 
 /**
  * 문서를 삭제 상태로 변경하는 함수
@@ -25,8 +26,8 @@ suspend fun DocumentReference.undel() {
  * @property deletedAt 삭제 서버 타임스탬프
  */
 private val DeleteHashMap = hashMapOf(
-    "updateAt" to FieldValue.serverTimestamp,
-    "deletedAt" to FieldValue.serverTimestamp
+    "updateAt" to FieldValue.serverTimestamp(),
+    "deletedAt" to FieldValue.serverTimestamp()
 )
 
 /**
@@ -35,7 +36,7 @@ private val DeleteHashMap = hashMapOf(
  * @property deletedAt 삭제 일시 (null)
  */
 private val UndeleteHashMap = hashMapOf(
-    "updateAt" to FieldValue.serverTimestamp,
+    "updateAt" to FieldValue.serverTimestamp(),
     "deletedAt" to null
 )
 

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Document.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/Document.kt
@@ -1,7 +1,9 @@
 package zone.ien.utils.firebase.firestore.utils
 
-import dev.gitlive.firebase.firestore.DocumentReference
 import kotlinx.coroutines.flow.filter
+import zone.ien.firebase.firestore.DocumentReference
+import zone.ien.firebase.firestore.metadata
+import zone.ien.firebase.firestore.snapshots
 
 /**
  * DocumentReference에서 스냅샷을 구독하는 함수
@@ -10,5 +12,5 @@ import kotlinx.coroutines.flow.filter
  */
 fun DocumentReference.getSnapshots(cache: Boolean = true) =
     snapshots(includeMetadataChanges = !cache)
-        .filter { !it.metadata.isFromCache || cache }
+        .filter { it?.metadata?.isFromCache == false || cache }
 

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/FetchFirestoreItem.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/firestore/utils/FetchFirestoreItem.kt
@@ -1,17 +1,22 @@
 package zone.ien.utils.firebase.firestore.utils
 
-import dev.gitlive.firebase.firestore.CollectionReference
-import dev.gitlive.firebase.firestore.DocumentSnapshot
-import dev.gitlive.firebase.firestore.FieldPath
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import zone.ien.firebase.firestore.CollectionReference
+import zone.ien.firebase.firestore.DocumentSnapshot
+import zone.ien.firebase.firestore.FieldPath
+import zone.ien.firebase.firestore.documentId
+import zone.ien.firebase.firestore.documents
+import zone.ien.firebase.firestore.where
 import zone.ien.utils.firebase.firestore.model.BaseFirestoreItem
+import kotlin.collections.associateBy
 
 suspend fun <T : BaseFirestoreItem> fetchItems(
     collection: CollectionReference,

--- a/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/kdatetime/KDateTime.kt
+++ b/cmp-firebase/src/commonMain/kotlin/zone/ien/utils/firebase/kdatetime/KDateTime.kt
@@ -6,7 +6,7 @@ import com.sunnychung.lib.multiplatform.kdatetime.KZoneOffset
 import com.sunnychung.lib.multiplatform.kdatetime.KZonedDateTime
 import com.sunnychung.lib.multiplatform.kdatetime.serializer.KInstantAsLong
 import com.sunnychung.lib.multiplatform.kdatetime.toKZonedDateTime
-import dev.gitlive.firebase.firestore.Timestamp
+import zone.ien.firebase.firestore.Timestamp
 
 /**
  * Timestamp를 KDate로 변환하는 확장 함수

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.4.10"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.1.0"
+lib-version-name = "3.1.0-alpha01"
 
 # plugin
 compose-plugin = "1.11.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ compose-plugin-experimental = "1.11.0-alpha07"
 compose-navigation3 = "1.1.1"
 
 # firebase
-kmp-firebase = "1.0.0-beta04"
+kmp-firebase = "1.0.0-beta08"
 firebase-firestore = "26.4.1"
 firebase-storage = "22.0.1"
 firebase-common = "22.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.4.10"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.0.1"
+lib-version-name = "3.1.0"
 
 # plugin
 compose-plugin = "1.11.1"
@@ -12,7 +12,7 @@ compose-plugin-experimental = "1.11.0-alpha07"
 compose-navigation3 = "1.1.1"
 
 # firebase
-kmp-firebase = "2.5.0"
+kmp-firebase = "1.0.0-beta04"
 firebase-firestore = "26.4.1"
 firebase-storage = "22.0.1"
 firebase-common = "22.1.0"
@@ -50,8 +50,8 @@ androidx-core = "1.19.0"
 [libraries]
 
 # firebase
-firebase-firestore = { group = "dev.gitlive", name = "firebase-firestore", version.ref = "kmp-firebase" }
-firebase-storage = { group = "dev.gitlive", name = "firebase-storage", version.ref = "kmp-firebase" }
+firebase-firestore = { group = "zone.ien.firebase", name = "firebase-firestore", version.ref = "kmp-firebase" }
+firebase-storage = { group = "zone.ien.firebase", name = "firebase-storage", version.ref = "kmp-firebase" }
 firebase-firestore-android = { group = "com.google.firebase", name = "firebase-firestore", version.ref = "firebase-firestore" }
 firebase-storage-android = { group = "com.google.firebase", name = "firebase-storage", version.ref = "firebase-storage" }
 firebase-common-android = { group = "com.google.firebase", name = "firebase-common", version.ref = "firebase-common" }


### PR DESCRIPTION
## 요약
Firebase 의존성을 dev.gitlive에서 커스텀 zone.ien.firebase 패키지로 이관하고, 프로젝트 Git 브랜치 전략 및 커밋 메시지 규칙을 문서화했습니다.

## 주요 변경사항
- **Firebase 패키지 이관**: gradle/libs.versions.toml에서 dev.gitlive 의존성을 zone.ien.firebase:1.0.0-beta08로 이관 및 cmp-filekit, cmp-firebase 패키지 import 업데이트
- **Firestore API 업데이트**: FieldValue.serverTimestamp() 함수 호출 수정 및 snapshot/metadata 접근 변경
- **Git 브랜치 전략 문서화**: README.md에 브랜치 토폴로지, 머지 규칙, 커밋 메시지 정규식 안내 작성
- **Gradle Task 추가**: installGitHooks task를 통해 .githooks 경로 설정 자동화
- **버전 업데이트**: 라이브러리 버전을 3.1.0-alpha01로 변경

## 확인 사항
- zone.ien.firebase 의존성으로 컴파일 및 런타임 동작 정상 여부
- ./gradlew installGitHooks 실행 테스트

## 영향 범위
- cmp-firebase 및 cmp-filekit 라이브러리 전체