### PR TITLE
⚡ perf(core): 라이브러리 버전 업데이트 및 kmp-firebase 1.0.0 적용

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.4.10"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.1.0"
+lib-version-name = "3.1.1-alpha04"
 
 # plugin
 compose-plugin = "1.11.1"
@@ -13,7 +13,7 @@ compose-navigation3 = "1.1.1"
 buildkonfig = "0.22.0"
 
 # firebase
-kmp-firebase = "1.0.0-beta08"
+kmp-firebase = "1.0.0"
 firebase-firestore = "26.4.1"
 firebase-storage = "22.0.1"
 firebase-common = "22.1.0"
@@ -35,8 +35,8 @@ kotlin-coroutine = "1.11.0"
 startup-runtime = "1.2.0"
 kotlinx-io-core = "0.9.1"
 filekit = "0.14.2"
-androidx-credentials = "1.3.0"
-googleid = "1.1.1"
+androidx-credentials = "1.6.0"
+googleid = "1.2.0"
 
 # backend
 vanniktechMavenPublish = "0.37.0"


### PR DESCRIPTION
## 요약
- kmp-firebase 라이브러리를 1.0.0 정식 버전으로 업데이트하고 관련 의존성 버전을 갱신합니다.

## 주요 변경사항
- `lib-version-name`을 `3.1.1-alpha04`로 변경
- `kmp-firebase` 버전을 `1.0.0-beta08`에서 `1.0.0` 정식 버전으로 업데이트
- `androidx-credentials` (1.3.0 → 1.6.0) 및 `googleid` (1.1.1 → 1.2.0) 의존성 라이브러리 버전 업데이트

## 확인 사항
- kmp-firebase 1.0.0 정식 버전 반영에 따른 빌드 및 호환성 확인

## 영향 범위
- Core 및 Firebase 라이브러리 의존성