### PR TITLE
✨ feat(ui): 스크롤 버블과 JVM 21 타깃 정리

### DIFF
--- a/cmp-adaptive/build.gradle.kts
+++ b/cmp-adaptive/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
             implementation(libs.bundles.hig)
 
             implementation(libs.placeholder)
+            implementation(libs.compose.inputactions)
 
             implementation(projects.cmpUi)
             implementation(projects.cmpCommon)
@@ -67,5 +68,4 @@ kotlin {
 dependencies {
     androidRuntimeClasspath(libs.compose.ui.tooling)
 }
-
 

--- a/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/wrapper/RootWrapper.kt
+++ b/cmp-adaptive/src/commonMain/kotlin/zone/ien/utils/adaptive/wrapper/RootWrapper.kt
@@ -1,55 +1,30 @@
 package zone.ien.utils.adaptive.wrapper
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
-import org.jetbrains.compose.resources.stringResource
-import zone.ien.hig.CupertinoIcon
-import zone.ien.hig.CupertinoLiquidButton
-import zone.ien.hig.CupertinoLiquidButtonDefaults
-import zone.ien.hig.ExperimentalCupertinoApi
 import zone.ien.hig.adaptive.AdaptiveScaffold
 import zone.ien.hig.adaptive.AdaptiveWidget
 import zone.ien.hig.adaptive.ExperimentalAdaptiveApi
-import zone.ien.hig.adaptive.icons.AdaptiveIcons
-import zone.ien.hig.icons.CupertinoIcons
-import zone.ien.hig.icons.outlined.ChevronDown
-import zone.ien.hig.icons.outlined.ChevronUp
 import zone.ien.hig.utils.rememberDefaultBackdrop
-import zone.ien.utils.cmp_ui.generated.resources.Res
-import zone.ien.utils.cmp_ui.generated.resources.close
-import zone.ien.utils.cmp_ui.generated.resources.next
-import zone.ien.utils.cmp_ui.generated.resources.previous
+import zone.ien.inputactions.InputAction
+import zone.ien.inputactions.InputActionStyle
+import zone.ien.inputactions.InputActionsHost
+import zone.ien.inputactions.inputActions
 import zone.ien.utils.isIos
+import zone.ien.utils.ui.interactive.IenTextField
 import zone.ien.utils.ui.screen.LocalEnableImePadding
 import zone.ien.utils.ui.screen.LocalSetEnableImePadding
 import zone.ien.utils.ui.utils.advancedImePadding
@@ -64,130 +39,54 @@ import zone.ien.utils.ui.utils.keyboardAsState
  * 키보드 처리 및 레이아웃 조정을 제공합니다.
  * 
  * @param modifier 래퍼에 적용할 수정자
- * @param showKeyboardDirection 키보드 방향 표시 여부
  * @param enableImePadding 키보드 입력 패딩 사용 여부
  * @param notification 알림 콘텐츠 컴포저블
  * @param content 메인 콘텐츠 컴포저블
  */
-@OptIn(ExperimentalAdaptiveApi::class, ExperimentalCupertinoApi::class)
+@OptIn(ExperimentalAdaptiveApi::class)
 @Composable
 fun RootWrapper(
     modifier: Modifier = Modifier,
-    showKeyboardDirection: Boolean = false,
     enableImePadding: Boolean = true,
     notification: @Composable () -> Unit = {},
     content: @Composable (Modifier) -> Unit
 ) {
     val isKeyboardVisible by keyboardAsState()
-    val keyboardManager = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current
     val backdrop = rememberDefaultBackdrop()
     var localEnableImePadding by remember { mutableStateOf(enableImePadding) }
 
-    CompositionLocalProvider(
-        LocalEnableImePadding provides localEnableImePadding,
-        LocalSetEnableImePadding provides { localEnableImePadding = it }
-    ) {
-        AdaptiveScaffold(
-            contentWindowInsets = WindowInsets(0.dp),
-            modifier = modifier
+    InputActionsHost {
+        CompositionLocalProvider(
+            LocalEnableImePadding provides localEnableImePadding,
+            LocalSetEnableImePadding provides { localEnableImePadding = it }
         ) {
-            Box(
-                modifier = Modifier
-                    .conditional(localEnableImePadding) { advancedImePadding(!isIos) }
-                    .dragToKeyboardClose(isKeyboardVisible)
-                    .padding(it)
+            AdaptiveScaffold(
+                contentWindowInsets = WindowInsets(0.dp),
+                modifier = modifier
             ) {
                 Box(
-                    contentAlignment = Alignment.BottomCenter,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .conditional(localEnableImePadding) { advancedImePadding(!isIos) }
+                        .dragToKeyboardClose(isKeyboardVisible)
+                        .padding(it)
                 ) {
-                    content(
-                        Modifier
-                            .layerBackdrop(backdrop)
-                    )
-                    AnimatedVisibility(
-                        visible = isKeyboardVisible && isIos,
-                        enter = fadeIn(tween(150)) + expandVertically(tween(150)),
-                        exit = fadeOut(tween(150)) + shrinkVertically(tween(150))
+                    Box(
+                        contentAlignment = Alignment.BottomCenter,
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Row(
-                            modifier = Modifier
-                                .padding(horizontal = 16.dp, vertical = 8.dp)
-                                .fillMaxWidth()
-                        ) {
-                            if (showKeyboardDirection) {
-                                CupertinoLiquidButton(
-                                    backdrop = backdrop,
-                                    onClick = {},
-                                    isInteractive = false,
-                                    modifier = Modifier.fillMaxWidth()
-                                ) {
-                                    Box(
-                                        modifier = Modifier.clickable(
-                                            onClick = { focusManager.moveFocus(FocusDirection.Previous) },
-                                            indication = null,
-                                            interactionSource = null
-                                        )
-                                    ) {
-                                        CupertinoIcon(
-                                            painter = AdaptiveIcons.painter(
-                                                material = { CupertinoIcons.Default.ChevronUp },
-                                                cupertino = { "chevron.up" }
-                                            ),
-                                            contentDescription = stringResource(Res.string.previous)
-                                        )
-                                    }
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Box(
-                                        modifier = Modifier.clickable(
-                                            onClick = { focusManager.moveFocus(FocusDirection.Next) },
-                                            indication = null,
-                                            interactionSource = null
-                                        )
-                                    ) {
-                                        CupertinoIcon(
-                                            painter = AdaptiveIcons.painter(
-                                                material = { CupertinoIcons.Default.ChevronDown },
-                                                cupertino = { "chevron.down" }
-                                            ),
-                                            contentDescription = stringResource(Res.string.next)
-                                        )
-                                    }
-                                    Spacer(modifier = Modifier.weight(1f))
-                                    Box(
-                                        modifier = Modifier.clickable(
-                                            onClick = { keyboardManager?.hide() },
-                                            indication = null,
-                                            interactionSource = null
-                                        )
-                                    ) {
-                                        Text(text = stringResource(Res.string.close))
-                                    }
-                                }
-                            } else {
-                                Spacer(modifier = Modifier.weight(1f))
-                                CupertinoLiquidButton(
-                                    backdrop = backdrop,
-                                    colors = CupertinoLiquidButtonDefaults.glassProminentButtonColors(),
-                                    onClick = { keyboardManager?.hide() }
-                                ) {
-                                    Text(
-                                        text = stringResource(Res.string.close),
-                                        fontWeight = FontWeight.Bold
-                                    )
-                                }
-                            }
-                        }
+                        content(
+                            Modifier
+                                .layerBackdrop(backdrop)
+                        )
                     }
-                }
 
-                AdaptiveWidget(
-                    material = {},
-                    cupertino = {
-                        notification()
-                    }
-                )
+                    AdaptiveWidget(
+                        material = {},
+                        cupertino = {
+                            notification()
+                        }
+                    )
+                }
             }
         }
     }

--- a/cmp-firebase/build.gradle.kts
+++ b/cmp-firebase/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
         }
 
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_25)
+            jvmTarget.set(JvmTarget.JVM_21)
         }
     }
     iosArm64()

--- a/cmp-navigation/build.gradle.kts
+++ b/cmp-navigation/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
@@ -23,6 +25,10 @@ kotlin {
             sourceSetTreeName = "test"
         }.configure {
             instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
+
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_21)
         }
     }
     iosArm64()

--- a/cmp-ui/build.gradle.kts
+++ b/cmp-ui/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
             implementation(libs.hig.core)
             implementation(libs.backdrop)
             implementation(libs.capsule)
+            implementation(libs.compose.inputactions)
 
             implementation(projects.cmpCommon)
             implementation(projects.cmpIcon)

--- a/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/list/ScrollingBubble.kt
+++ b/cmp-ui/src/commonMain/kotlin/zone/ien/utils/ui/list/ScrollingBubble.kt
@@ -1,0 +1,209 @@
+package zone.ien.utils.ui.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+import zone.ien.utils.ui.foundation.IenTheme
+
+private val ScrollingBubbleSize = 112.dp
+private val ScrollingBubbleMinThumbHeight = 48.dp
+private val ScrollingBubbleScrollbarWidth = 4.dp
+private val ScrollingBubbleGap = 8.dp
+private val ScrollingBubbleShape = RoundedCornerShape(
+    topStart = 56.dp,
+    topEnd = 0.dp,
+    bottomEnd = 0.dp,
+    bottomStart = 56.dp,
+)
+
+private data class ScrollingBubbleData(
+    val index: Int,
+    val firstVisibleItemScrollOffset: Int,
+    val firstVisibleItemSize: Int,
+    val visibleItemCount: Int,
+    val totalItemCount: Int,
+)
+
+/**
+ * 리스트를 스크롤하는 동안 스크롤바 썸과 함께 현재 항목을 버블로 보여주는 컨테이너입니다.
+ *
+ * [content]에는 [state]를 사용하는 Lazy 리스트를 전달하고, [bubbleContent]에서는
+ * 현재 첫 번째 표시 항목의 인덱스를 이용해 버블 내용을 구성할 수 있습니다. 버블은
+ * 스크롤 영역의 오른쪽에 배치되며 현재 스크롤 위치에 따라 세로로 이동합니다.
+ *
+ * @param state 콘텐츠에 연결된 [LazyListState]
+ * @param modifier 컨테이너에 적용할 [Modifier]
+ * @param bubbleContent 스크롤 중인 항목 인덱스로 버블 내부를 구성하는 슬롯
+ * @param content 스크롤 가능한 리스트 콘텐츠
+ */
+@Composable
+fun ScrollingBubble(
+    state: LazyListState,
+    modifier: Modifier = Modifier,
+    bubbleContent: @Composable (index: Int) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val bubbleData by remember(state) {
+        derivedStateOf {
+            val layoutInfo = state.layoutInfo
+            val firstVisibleItem = layoutInfo.visibleItemsInfo.firstOrNull()
+            val index = scrollingBubbleIndex(
+                isScrollInProgress = state.isScrollInProgress,
+                firstVisibleItemIndex = state.firstVisibleItemIndex,
+                itemCount = layoutInfo.totalItemsCount,
+            )
+
+            if (index == null || firstVisibleItem == null) {
+                null
+            } else {
+                ScrollingBubbleData(
+                    index = index,
+                    firstVisibleItemScrollOffset = state.firstVisibleItemScrollOffset,
+                    firstVisibleItemSize = firstVisibleItem.size,
+                    visibleItemCount = layoutInfo.visibleItemsInfo.size,
+                    totalItemCount = layoutInfo.totalItemsCount,
+                )
+            }
+        }
+    }
+
+    BoxWithConstraints(modifier = modifier) {
+        content()
+
+        val density = androidx.compose.ui.platform.LocalDensity.current
+        val trackHeightPx = with(density) { maxHeight.toPx() }
+        val bubbleHeightPx = with(density) { ScrollingBubbleSize.toPx() }
+        val minimumThumbHeightPx = with(density) { ScrollingBubbleMinThumbHeight.toPx() }
+        val horizontalOffsetPx = with(density) {
+            -(ScrollingBubbleScrollbarWidth + ScrollingBubbleGap).roundToPx()
+        }
+        val data = bubbleData
+        val position = data?.let { data ->
+            scrollingBubblePosition(
+                trackHeight = trackHeightPx,
+                bubbleHeight = bubbleHeightPx,
+                firstVisibleItemIndex = data.index,
+                firstVisibleItemScrollOffset = data.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = data.firstVisibleItemSize,
+                visibleItemCount = data.visibleItemCount,
+                totalItemCount = data.totalItemCount,
+                minimumThumbHeight = minimumThumbHeightPx,
+            )
+        }
+
+        if (position != null) {
+            val thumbHeight = with(density) { position.thumbHeight.toDp() }
+            val scrollbarColor = IenTheme.colors.border.copy(alpha = 0.72f)
+            val bubbleIndex = data.index
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .fillMaxHeight()
+                    .width(ScrollingBubbleScrollbarWidth)
+                    .background(scrollbarColor),
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset { IntOffset(0, position.thumbTop.roundToInt()) }
+                    .width(ScrollingBubbleScrollbarWidth)
+                    .height(thumbHeight)
+                    .background(IenTheme.colors.brand),
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset { IntOffset(horizontalOffsetPx, position.bubbleTop.roundToInt()) }
+                    .size(ScrollingBubbleSize)
+                    .clip(ScrollingBubbleShape)
+                    .background(IenTheme.colors.brand),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProvider(LocalContentColor provides IenTheme.colors.onBrand) {
+                    bubbleContent(bubbleIndex)
+                }
+            }
+        }
+    }
+}
+
+internal fun scrollingBubbleIndex(
+    isScrollInProgress: Boolean,
+    firstVisibleItemIndex: Int,
+    itemCount: Int,
+): Int? {
+    return firstVisibleItemIndex.takeIf {
+        isScrollInProgress && itemCount > 0 && it in 0 until itemCount
+    }
+}
+
+internal data class ScrollingBubblePosition(
+    val thumbTop: Float,
+    val thumbHeight: Float,
+    val bubbleTop: Float,
+)
+
+internal fun scrollingBubblePosition(
+    trackHeight: Float,
+    bubbleHeight: Float,
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    firstVisibleItemSize: Int,
+    visibleItemCount: Int,
+    totalItemCount: Int,
+    minimumThumbHeight: Float,
+): ScrollingBubblePosition? {
+    if (
+        !trackHeight.isFinite() ||
+        trackHeight <= 0f ||
+        bubbleHeight <= 0f ||
+        firstVisibleItemIndex < 0 ||
+        firstVisibleItemScrollOffset < 0 ||
+        firstVisibleItemSize <= 0 ||
+        visibleItemCount <= 0 ||
+        totalItemCount <= visibleItemCount
+    ) {
+        return null
+    }
+
+    val maxScrollOffset = ((totalItemCount - visibleItemCount) * firstVisibleItemSize).toFloat()
+    if (maxScrollOffset <= 0f) return null
+
+    val scrollOffset = (
+        firstVisibleItemIndex * firstVisibleItemSize + firstVisibleItemScrollOffset
+        ).toFloat()
+    val scrollFraction = (scrollOffset / maxScrollOffset).coerceIn(0f, 1f)
+    val thumbHeight = (trackHeight * visibleItemCount / totalItemCount)
+        .coerceAtLeast(minimumThumbHeight)
+        .coerceAtMost(trackHeight)
+    val thumbTop = (trackHeight - thumbHeight) * scrollFraction
+    val bubbleTop = (
+        thumbTop + (thumbHeight - bubbleHeight) / 2f
+        ).coerceIn(0f, (trackHeight - bubbleHeight).coerceAtLeast(0f))
+
+    return ScrollingBubblePosition(
+        thumbTop = thumbTop,
+        thumbHeight = thumbHeight,
+        bubbleTop = bubbleTop,
+    )
+}

--- a/cmp-ui/src/commonTest/kotlin/zone/ien/utils/ui/list/ScrollingBubbleTest.kt
+++ b/cmp-ui/src/commonTest/kotlin/zone/ien/utils/ui/list/ScrollingBubbleTest.kt
@@ -1,0 +1,91 @@
+package zone.ien.utils.ui.list
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ScrollingBubbleTest {
+    @Test
+    fun `스크롤 중에는 첫 번째 표시 항목 인덱스를 버블에 전달한다`() {
+        assertEquals(
+            expected = 3,
+            actual = scrollingBubbleIndex(
+                isScrollInProgress = true,
+                firstVisibleItemIndex = 3,
+                itemCount = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `스크롤 중이 아니면 버블을 표시하지 않는다`() {
+        assertNull(
+            scrollingBubbleIndex(
+                isScrollInProgress = false,
+                firstVisibleItemIndex = 3,
+                itemCount = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `빈 목록이나 범위를 벗어난 인덱스에서는 버블을 표시하지 않는다`() {
+        assertNull(
+            scrollingBubbleIndex(
+                isScrollInProgress = true,
+                firstVisibleItemIndex = 0,
+                itemCount = 0,
+            ),
+        )
+        assertNull(
+            scrollingBubbleIndex(
+                isScrollInProgress = true,
+                firstVisibleItemIndex = 10,
+                itemCount = 10,
+            ),
+        )
+        assertNull(
+            scrollingBubbleIndex(
+                isScrollInProgress = true,
+                firstVisibleItemIndex = -1,
+                itemCount = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `스크롤 진행률에 따라 버블과 썸의 위치를 계산한다`() {
+        val position = scrollingBubblePosition(
+            trackHeight = 1_000f,
+            bubbleHeight = 120f,
+            firstVisibleItemIndex = 20,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 50,
+            visibleItemCount = 10,
+            totalItemCount = 50,
+            minimumThumbHeight = 48f,
+        )
+
+        assertNotNull(position)
+        assertEquals(200f, position.thumbHeight)
+        assertEquals(400f, position.thumbTop)
+        assertEquals(440f, position.bubbleTop)
+    }
+
+    @Test
+    fun `스크롤할 수 없는 목록에서는 버블 위치를 계산하지 않는다`() {
+        val position = scrollingBubblePosition(
+            trackHeight = 1_000f,
+            bubbleHeight = 120f,
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 50,
+            visibleItemCount = 10,
+            totalItemCount = 10,
+            minimumThumbHeight = 48f,
+        )
+
+        assertNull(position)
+    }
+}

--- a/example/composeApp/build.gradle.kts
+++ b/example/composeApp/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         minSdk = libs.versions.android.minSdk.get().toInt()
 
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_25)
+            jvmTarget.set(JvmTarget.JVM_21)
         }
 
         androidResources {

--- a/example/composeApp/build.gradle.kts
+++ b/example/composeApp/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
             implementation(libs.placeholder)
 
             implementation(libs.bundles.koin)
+            implementation(libs.compose.inputactions)
 
             implementation(projects.cmpCommon)
             implementation(projects.cmpAdaptive)

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/navigation/RootNavigationGraph.kt
@@ -20,6 +20,7 @@ import zone.ien.utils.example.ui.screens.playground.IenPlaygroundScreen
 import zone.ien.utils.example.ui.screens.section.SectionScreen
 import zone.ien.utils.example.ui.screens.settings.SettingsScreen
 import zone.ien.utils.example.ui.screens.auth.FirebaseAuthScreen
+import zone.ien.utils.example.ui.screens.scrollingbubble.ScrollingBubbleScreen
 import zone.ien.utils.navigation.BaseNavDisplay
 import zone.ien.utils.navigation.getConfig
 import zone.ien.utils.navigation.navigateBack
@@ -38,6 +39,7 @@ sealed interface RootRoute: NavKey {
     @Serializable data object DesignSystem: RootRoute
     @Serializable data object ColorTokens: RootRoute
     @Serializable data object FirebaseAuth: RootRoute
+    @Serializable data object ScrollingBubble: RootRoute
 }
 
 @Composable
@@ -107,6 +109,11 @@ fun RootNavigationGraph(
             entry<RootRoute.FirebaseAuth> {
                 FirebaseAuthScreen(
                     navigateBack = { backStack.navigateBack() }
+                )
+            }
+            entry<RootRoute.ScrollingBubble> {
+                ScrollingBubbleScreen(
+                    navigateBack = { backStack.navigateBack() },
                 )
             }
         }

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/home/HomeScreen.kt
@@ -79,6 +79,9 @@ import zone.ien.utils.utils.moveToBackground
 import zone.ien.utils.utils.shareText
 import zone.ien.utils.utils.ui.enableNativeInput
 import zone.ien.utils.utils.ui.rememberRepeatClick
+import zone.ien.inputactions.InputAction
+import zone.ien.inputactions.InputActionStyle
+import zone.ien.inputactions.inputActions
 
 
 private data class HomeMenuItem(
@@ -98,6 +101,7 @@ private val menuItems = listOf(
     HomeMenuItem("Adaptive Playground", RootRoute.AdaptivePlayground, Color(0xFF0F766E)),
     HomeMenuItem("Navigation", RootRoute.Navigation, Color(0xFFFDD835)),
     HomeMenuItem("Firebase Auth", RootRoute.FirebaseAuth, Color(0xFFE65100)),
+    HomeMenuItem("Scrolling Bubble", RootRoute.ScrollingBubble, Color(0xFF3949AB)),
 )
 
 @Suppress("FrequentlyChangingValue")
@@ -292,7 +296,15 @@ fun HomeScreen(
                     IenTextField(
                         value = bottomText,
                         onValueChange = { bottomText = it },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .inputActions(
+                                InputAction(
+                                    title = "Done",
+                                    style = InputActionStyle.Done,
+                                    onClick = {}
+                                )
+                            )
                     )
                 }
             },

--- a/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/scrollingbubble/ScrollingBubbleScreen.kt
+++ b/example/composeApp/src/commonMain/kotlin/zone/ien/utils/example/ui/screens/scrollingbubble/ScrollingBubbleScreen.kt
@@ -1,0 +1,151 @@
+package zone.ien.utils.example.ui.screens.scrollingbubble
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import zone.ien.utils.ui.foundation.IenTheme
+import zone.ien.utils.ui.list.ScrollingBubble
+import zone.ien.utils.ui.primitives.IenText
+import zone.ien.utils.ui.interactive.IenTextButton
+import zone.ien.utils.ui.screen.IenScaffold
+import zone.ien.utils.ui.screen.IenScaffoldContentEdge
+import zone.ien.utils.ui.screen.IenTopBar
+
+internal val scrollingBubbleSampleItems = listOf(
+    "Ackee",
+    "Acerola",
+    "Apple",
+    "Apricot",
+    "Asian Pear",
+    "Atemoya",
+    "Avocado",
+    "Banana",
+    "Blackcurrant",
+    "Blackberry",
+    "Blueberry",
+    "Boysenberry",
+    "Breadfruit",
+    "Buddha's Hand",
+    "Cantaloupe",
+    "Cherry",
+    "Clementine",
+    "Coconut",
+    "Crabapple",
+    "Cranberry",
+    "Currant",
+    "Damson",
+    "Dangleberry",
+    "Date",
+    "Dewberry",
+    "Desert Lime",
+    "Dragon Fruit",
+    "Durian",
+    "Elderberry",
+    "Eggfruit",
+    "Emblic",
+    "Feijoa",
+    "Fig",
+    "Finger Lime",
+    "Genip",
+    "Goldenberry",
+    "Grape",
+    "Grapefruit",
+    "Gooseberry",
+    "Governor's Plum",
+    "Guava",
+    "Hackberry",
+    "Hawthorn Fruit",
+    "Honeydew",
+    "Huckleberry",
+    "Jabuticaba",
+    "Jackfruit",
+    "Jujube",
+    "Juneberry",
+    "Kiwi",
+    "Kiwano",
+    "Korlan",
+    "Kumquat",
+    "Lemon",
+    "Lime",
+    "Longan",
+    "Lychee",
+    "Mango",
+    "Mangosteen",
+    "Melon",
+    "Mulberry",
+    "Nance",
+    "Naranjilla",
+    "Nectarine",
+    "Nutmeg Fruit",
+    "Orange",
+    "Peach",
+    "Pear",
+    "Pineapple",
+    "Raspberry",
+    "Strawberry",
+    "Watermelon",
+)
+
+@Composable
+fun ScrollingBubbleScreen(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit,
+) {
+    IenTheme {
+        val lazyListState = rememberLazyListState()
+
+        IenScaffold(
+            modifier = modifier,
+            contentEdge = IenScaffoldContentEdge(
+                lazyListState = lazyListState,
+            ),
+            topBar = {
+                IenTopBar(
+                    title = "Scrolling Bubble",
+                    subtitle = "스크롤 위치를 따라 움직이는 버블",
+                    navigationIcon = {
+                        IenTextButton(onClick = navigateBack) {
+                            IenText("닫기")
+                        }
+                    },
+                )
+            },
+        ) { contentPadding ->
+            ScrollingBubble(
+                state = lazyListState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding),
+                bubbleContent = { index ->
+                    IenText(
+                        text = scrollingBubbleSampleItems[index].first().uppercase(),
+                        style = IenTheme.typography.title1,
+                    )
+                },
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(scrollingBubbleSampleItems) { item ->
+                        IenText(
+                            text = item,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    horizontal = IenTheme.spacing.md,
+                                    vertical = IenTheme.spacing.sm,
+                                ),
+                            style = IenTheme.typography.body2,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example/composeApp/src/commonTest/kotlin/zone/ien/utils/example/ui/screens/scrollingbubble/ScrollingBubbleScreenTest.kt
+++ b/example/composeApp/src/commonTest/kotlin/zone/ien/utils/example/ui/screens/scrollingbubble/ScrollingBubbleScreenTest.kt
@@ -1,0 +1,16 @@
+package zone.ien.utils.example.ui.screens.scrollingbubble
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import zone.ien.utils.example.ui.navigation.RootRoute
+
+class ScrollingBubbleScreenTest {
+    @Test
+    fun `스크롤 버블 샘플 라우트와 항목을 제공한다`() {
+        val route: RootRoute = RootRoute.ScrollingBubble
+
+        assertEquals(RootRoute.ScrollingBubble, route)
+        assertEquals("Ackee", scrollingBubbleSampleItems.first())
+        assertEquals(72, scrollingBubbleSampleItems.size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.4.20-RC2"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.4.0-alpha01"
+lib-version-name = "3.4.0-alpha02"
 
 # plugin
 compose-plugin = "1.12.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,22 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.4.10"
+kotlin = "2.4.20-RC2"
 android-minSdk = "29"
 android-compileSdk = "37"
 android-targetSdk = "37"
-lib-version-name = "3.3.0"
+lib-version-name = "3.4.0-alpha01"
 
 # plugin
-compose-plugin = "1.12.0-rc01"
+compose-plugin = "1.12.0"
 compose-plugin-experimental = "1.12.0-alpha03"
 compose-navigation3 = "1.1.1"
 buildkonfig = "0.22.0"
 
 # firebase
 kmp-firebase = "1.0.0"
-firebase-firestore = "26.4.1"
+firebase-firestore = "26.6.0"
 firebase-storage = "22.0.1"
-firebase-common = "22.1.0"
+firebase-common = "22.2.0"
 firebase-auth = "24.2.0"
 google-services = "4.5.0"
 
@@ -24,10 +24,11 @@ google-services = "4.5.0"
 activity-compose = "1.13.0"
 lifecycle = "2.11.0"
 backdrop = "2.0.0"
-haze = "1.7.2"
+haze = "1.7.3"
 hig = "1.3.1"
 capsule = "2.1.4"
 placeholder = "1.0.3"
+compose-inputactions = "0.9.0-alpha02"
 
 # functionality
 kdatetime = "1.1.2"
@@ -84,6 +85,7 @@ hig-icons = { group = "zone.ien.hig", name = "hig-icons-extended", version.ref =
 capsule = { group = "zone.ien.capsule", name = "capsule", version.ref = "capsule" }
 
 placeholder = { group = "com.revenuecat.purchases", name = "placeholder", version.ref = "placeholder"}
+compose-inputactions = { group = "zone.ien.inputactions", name = "inputactions", version.ref = "compose-inputactions" }
 
 # functionality
 kdatetime = { group = "io.github.sunny-chung", name = "kdatetime-multiplatform", version.ref = "kdatetime" }


### PR DESCRIPTION
## 요약
- `cmp-ui`에 재사용 가능한 `ScrollingBubble` 컴포넌트와 테스트를 추가합니다.
- 예제 앱에서 스크롤 버블 화면을 확인할 수 있도록 라우트와 홈 메뉴를 연결합니다.
- Android 컴파일 JVM 타깃을 21로 통일해 JVM 25 인라인 바이트코드 오류를 해결합니다.

## 주요 변경사항
- `ScrollingBubble`의 스크롤 진행률, 썸 크기·위치, 버블 위치 계산과 공통 테스트를 추가했습니다.
- 예제 앱에 과일 목록 기반 `ScrollingBubbleScreen`을 추가하고 네비게이션 및 홈 메뉴에 연결했습니다.
- `RootWrapper`의 수동 키보드 액세서리 바를 제거하고 `InputActionsHost` 기반 입력 액션을 적용했습니다.
- `cmp-navigation`, `cmp-firebase`, `example:composeApp`의 Android `jvmTarget`을 `JVM_21`로 설정했습니다.
- `compose-inputactions` 의존성을 연결하고 Kotlin, Compose, Firebase, Haze 및 라이브러리 버전을 갱신했습니다.

## 확인 사항
- `:cmp-navigation:compileAndroidMain :cmp-firebase:compileAndroidMain :example:composeApp:compileAndroidMain :example:androidApp:compileDebugKotlin` 통과 (`BUILD SUCCESSFUL`)
- `:cmp-ui:testAndroidHostTest` 통과 (`BUILD SUCCESSFUL`)
- `git diff --check origin/dev...HEAD` 통과
- 리뷰 시 `RootWrapper`의 입력 액션 전환과 `ScrollingBubble`의 위치 계산 및 표시 조건을 중점적으로 확인해 주세요.

## 영향 범위
- `cmp-ui`의 새 공개 UI 컴포넌트 및 공통 테스트
- `cmp-adaptive`의 키보드 입력 액션 호스트 동작
- 예제 앱의 화면·네비게이션·홈 메뉴
- Gradle 버전 카탈로그와 Android JVM 컴파일 설정